### PR TITLE
3.3

### DIFF
--- a/railo-java/railo-core/src/resource/component/org/railo/cfml/Query.cfc
+++ b/railo-java/railo-core/src/resource/component/org/railo/cfml/Query.cfc
@@ -20,9 +20,12 @@ component output="false" extends="Base" accessors="true"{
 	/*
 	 * @hint Execute the query
 	 */	
-	public Result function execute(String sql=""){
-		if(len(arguments.sql)){
-			 setSql(arguments.sql);
+	public Result function execute(){
+		if(!structIsempty(arguments)){
+			structappend(variables.attributes,arguments,"yes");
+        }
+		if(structKeyExists(arguments,"sql") && len(arguments.sql)){
+			 this.setSql(arguments.sql);
 		}
 		
 		//parse the sql into an array and save it


### PR DESCRIPTION
Fix for issue 1440 so you can do qoq.execute(dbType-"query).getResults() like you can in CF9 for script-based query of queries. There was also a bug in which if you passed in an sql argument into execute() it would throw an error since it called setSQL() without using the THIS scope, which is needed because setSQL is implemented using onMissingMethod in the Base object.
