### PR TITLE
Duplicate time labels

### DIFF
--- a/railo-cfml/railo-admin/admin/server.regional.cfm
+++ b/railo-cfml/railo-admin/admin/server.regional.cfm
@@ -203,7 +203,6 @@ replaced with encoding output
 	<td colspan="2">
 	<span class="comment">
 		#stText.Overview.ServerTime#
-		#stText.Overview.DateTime#
 		#lsdateFormat(date:now(),timezone:"jvm")#
 		#lstimeFormat(time:now(),timezone:"jvm")#<br>
         


### PR DESCRIPTION
Removed a duplicate label that was showing the railo time label on the same line as the server time label.

The railo time label normally shows on the line under the server time.
