### PR TITLE
Fix for RAILO-1522 (acessible instead of accessible).

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/ComponentImpl.java
+++ b/railo-java/railo-core/src/railo/runtime/ComponentImpl.java
@@ -1677,8 +1677,8 @@ public final class ComponentImpl extends StructSupport implements Externalizable
         if(triggerDataMember && !isPrivate(pc)) {
         	return callGetter(pc,key);
         }
-        throw new ExpressionException("Component ["+getCallName()+"] has no acessible Member with name ["+key+"]","enable [trigger data member] in admininistrator to also invoke getters and setters");
-        //throw new ExpressionException("Component ["+getCallName()+"] has no acessible Member with name ["+name+"]");
+        throw new ExpressionException("Component ["+getCallName()+"] has no accessible Member with name ["+key+"]","enable [trigger data member] in admininistrator to also invoke getters and setters");
+        //throw new ExpressionException("Component ["+getCallName()+"] has no accessible Member with name ["+name+"]");
     }
 
     private Object callGetter(PageContext pc,Collection.Key key) throws PageException {
@@ -1689,7 +1689,7 @@ public final class ComponentImpl extends StructSupport implements Externalizable
                 return _call(pc,udf,null,ArrayUtil.OBJECT_EMPTY);
             }
         } 
-        throw new ExpressionException("Component ["+getCallName()+"] has no acessible Member with name ["+key+"]");
+        throw new ExpressionException("Component ["+getCallName()+"] has no accessible Member with name ["+key+"]");
 	}
     
     private Object callGetter(PageContext pc,Collection.Key key, Object defaultValue) {
@@ -1738,7 +1738,7 @@ public final class ComponentImpl extends StructSupport implements Externalizable
         if(triggerDataMember && !isPrivate(ThreadLocalPageContext.get())) {
         	return callGetter(ThreadLocalPageContext.get(),key);
         }
-        throw new ExpressionException("Component ["+getCallName()+"] has no acessible Member with name ["+key+"]");
+        throw new ExpressionException("Component ["+getCallName()+"] has no accessible Member with name ["+key+"]");
     }
 
     /**

--- a/railo-java/railo-core/src/railo/runtime/ComponentScopeShadow.java
+++ b/railo-java/railo-core/src/railo/runtime/ComponentScopeShadow.java
@@ -113,7 +113,7 @@ public class ComponentScopeShadow extends StructSupport implements ComponentScop
 	public Object get(Key key) throws PageException {
 		Object o = get(key,null);
 		if(o!=null) return o;
-        throw new ExpressionException("Component ["+component.getCallName()+"] has no acessible Member with name ["+key+"]");
+        throw new ExpressionException("Component ["+component.getCallName()+"] has no accessible Member with name ["+key+"]");
 	}
 	
 	/**


### PR DESCRIPTION
Fixed a spelling mistake that had been logged as https://issues.jboss.org/browse/RAILO-1522
