### PR TITLE
Clean up comments, typos, exceptions.

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayAppend.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayAppend.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arrayappend
+ * Implements the ColdFusion Function arrayAppend
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayAvg.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayAvg.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arrayavg
+ * Implements the ColdFusion Function arrayAvg
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayClear.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayClear.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arrayclear
+ * Implements the ColdFusion Function arrayClear
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayContains.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayContains.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function listcontains
+ * Implements the ColdFusion Function listContains
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayContainsNoCase.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayContainsNoCase.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function listcontainsnocase
+ * Implements the ColdFusion Function listContainsNoCase
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayDelete.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayDelete.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arraydeleteat
+ * Implements the ColdFusion Function arrayDelete
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayDeleteAt.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayDeleteAt.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arraydeleteat
+ * Implements the ColdFusion Function arrayDeleteAt
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayEach.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayEach.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arrayavg
+ * Implements the ColdFusion Function arrayAvg
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayFilter.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayFilter.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arrayavg
+ * Implements the ColdFusion Function arrayAvg
  */
 package railo.runtime.functions.arrays;
 
@@ -26,12 +26,12 @@ public final class ArrayFilter implements Function {
 		// check UDF return type
 		int type = filter.getReturnType();
 		if(type!=CFTypes.TYPE_BOOLEAN && type!=CFTypes.TYPE_ANY)
-			throw new ExpressionException("invalid return type ["+filter.getReturnTypeAsString()+"] for UDF Filter, valid return types are [boolean,any]");
+			throw new ExpressionException("Invalid return type ["+filter.getReturnTypeAsString()+"] for UDF Filter; valid return types are [boolean,any]");
 		
 		// check UDF arguments
 		FunctionArgument[] args = filter.getFunctionArguments();
 		if(args.length>1)
-			throw new ExpressionException("UDF filter has to many arguments ["+args.length+"], should have at maximum 1 argument");
+			throw new ExpressionException("UDF filter has too many arguments ["+args.length+"]; should have at maximum 1 argument");
 		
 		
 		Array rtn=new ArrayImpl();

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayFirst.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayFirst.java
@@ -10,7 +10,7 @@ import railo.runtime.type.Array;
 public final class ArrayFirst implements Function {
 
     public static Object call(PageContext pc , Array array) throws PageException {
-        if(array.size()==0) throw new ExpressionException("can't return first element of array, array is empty");
+        if(array.size()==0) throw new ExpressionException("Cannot return first element of array; array is empty");
         return array.getE(1);
     }
     

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayIndexExists.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayIndexExists.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function structkeyexists
+ * Implements the ColdFusion Function structKeyExists
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayInsertAt.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayInsertAt.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arrayinsertat
+ * Implements the ColdFusion Function arrayInsertAt
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayIsDefined.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayIsDefined.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function structkeyexists
+ * Implements the ColdFusion Function arrayIsDefined
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayIsEmpty.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayIsEmpty.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arrayisempty
+ * Implements the ColdFusion Function arrayIsEmpty
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayLast.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayLast.java
@@ -10,7 +10,7 @@ import railo.runtime.type.Array;
 public final class ArrayLast implements Function {
 
     public static Object call(PageContext pc , Array array) throws PageException {
-        if(array.size()==0) throw new ExpressionException("can't return last element of array, array is empty");
+        if(array.size()==0) throw new ExpressionException("Cannot return last element of array; array is empty");
         return array.getE(array.size());
     }
     

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayLen.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayLen.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arraylen
+ * Implements the ColdFusion Function arrayLen
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayMax.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayMax.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arraymax
+ * Implements the ColdFusion Function arrayMax
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayMerge.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayMerge.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arrayMerge
+ * Implements the ColdFusion Function arrayMerge
  * Merge 2 arrays
  */
 package railo.runtime.functions.arrays;

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayMin.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayMin.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arraymin
+ * Implements the ColdFusion Function arrayMin
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayNew.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayNew.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arraynew
+ * Implements the ColdFusion Function arrayNew
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayPrepend.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayPrepend.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arrayprepend
+ * Implements the ColdFusion Function arrayPrepend
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayResize.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayResize.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arrayresize
+ * Implements the ColdFusion Function arrayResize
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayReverse.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayReverse.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arrayMerge
+ * Implements the ColdFusion Function arrayReverse
  * Merge 2 arrays
  */
 package railo.runtime.functions.arrays;

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArraySet.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArraySet.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arrayset
+ * Implements the ColdFusion Function arraySet
  */
 package railo.runtime.functions.arrays;
 
@@ -15,11 +15,11 @@ public final class ArraySet implements Function {
 		int f=(int) from;
 		int t=(int) to;
 		if(f<1)
-			throw new ExpressionException("second parameter of the function arraySet must be greater than zero, now ["+f+"]");
+			throw new ExpressionException("Second parameter of the function arraySet must be greater than zero; now ["+f+"]");
 		if(f>t)
-			throw new ExpressionException("third parameter of the function arraySet must be greater than second parameter now [second:"+f+", third:"+t+"]");
+			throw new ExpressionException("Third parameter of the function arraySet must be greater than the second parameter; now [second:"+f+", third:"+t+"]");
 		if(array.getDimension()>1)
-			throw new ExpressionException("function arraySet can only be used with 1 dimensional array, this array has "+array.getDimension()+" dimension");
+			throw new ExpressionException("Function arraySet can only be used with a one-dimensional array; this array has "+array.getDimension()+" dimensions");
         for(int i=f;i<=t;i++) {
 			array.setE(i,Duplicator.duplicate(value,true));
 		}

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArraySlice.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArraySlice.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arraymin
+ * Implements the ColdFusion Function arraySlice
  */
 package railo.runtime.functions.arrays;
 
@@ -21,13 +21,13 @@ public final class ArraySlice implements Function {
 				
 		int len=arr.size();
 		if(offset>0) {
-			if(len<offset)throw new FunctionException(pc,"arraySlice",2,"offset","offset cannot be greater than size of the array");
+			if(len<offset)throw new FunctionException(pc,"arraySlice",2,"offset","Offset cannot be greater than size of the array");
 			
 			int to=0;
 			if(length>0)to=(int)(offset+length-1);
 			else if(length<0)to=(int)(len+length);
 			if(len<to)
-				throw new FunctionException(pc,"arraySlice",3,"length","offset+length cannot be greater than size of the array");
+				throw new FunctionException(pc,"arraySlice",3,"length","Offset+length cannot be greater than size of the array");
 			
 			return get(arr,(int)offset,to);
 		}

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArraySort.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArraySort.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arraysort
+ * Implements the ColdFusion Function arraySort
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArraySum.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArraySum.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arraysum
+ * Implements the ColdFusion Function arraySum
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArraySwap.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArraySwap.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arrayswap
+ * Implements the ColdFusion Function arraySwap
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayToStruct.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/ArrayToStruct.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function arraymin
+ * Implements the ColdFusion Function arrayToStruct
  */
 package railo.runtime.functions.arrays;
 

--- a/railo-java/railo-core/src/railo/runtime/functions/arrays/Array_.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/arrays/Array_.java
@@ -1,5 +1,5 @@
 /**
- * Implements the Cold Fusion Function array
+ * Implements the ColdFusion Function array
  */
 package railo.runtime.functions.arrays;
 


### PR DESCRIPTION
Function names are wrong in some comments.
Improve consistency of exception messages and formatting.
Improve consistency of function naming in comments.
Fix misspelling in arrayAvg exception.
