### PR TITLE
Add path_info for Jetty when URL has been rewritten (RAILO-2053)

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/type/scope/CGIImpl.java
+++ b/railo-java/railo-core/src/railo/runtime/type/scope/CGIImpl.java
@@ -218,7 +218,7 @@ public final class CGIImpl extends ReadOnlyStruct implements CGI,ScriptProtected
             			String scriptName = ReqRspUtil.getScriptName(req);
 
             			if ( pathInfo != null && pathInfo.startsWith(scriptName) )
-						pathInfo = pathInfo.substring(scriptName.length());
+            				pathInfo = pathInfo.substring(scriptName.length());
             		}
             	    
             		if(!StringUtil.isEmpty(pathInfo,true)) return pathInfo;

--- a/railo-java/railo-core/src/railo/runtime/type/scope/CGIImpl.java
+++ b/railo-java/railo-core/src/railo/runtime/type/scope/CGIImpl.java
@@ -212,6 +212,14 @@ public final class CGIImpl extends ReadOnlyStruct implements CGI,ScriptProtected
             		String pathInfo = Caster.toString(req.getAttribute("javax.servlet.include.path_info"),null);
             		if(StringUtil.isEmpty(pathInfo)) pathInfo = Caster.toString(req.getHeader("xajp-path-info"),null);
             		if(StringUtil.isEmpty(pathInfo)) pathInfo = req.getPathInfo();
+            		if(StringUtil.isEmpty(pathInfo))
+            		{
+            			pathInfo = req.getAttribute("requestedPath").toString();
+            			String scriptName = ReqRspUtil.getScriptName(req);
+
+            			if ( pathInfo != null && pathInfo.startsWith(scriptName) )
+						pathInfo = pathInfo.substring(scriptName.length());
+            		}
             	    
             		if(!StringUtil.isEmpty(pathInfo,true)) return pathInfo;
             	    return "";


### PR DESCRIPTION
This change populates cgi.path_info for a Jetty request that has been re-written.

Related issue: https://issues.jboss.org/browse/RAILO-2053
