### PR TITLE
modified H2.cfc

### DIFF
--- a/railo-cfml/railo-admin/admin/dbdriver/H2.cfc
+++ b/railo-cfml/railo-admin/admin/dbdriver/H2.cfc
@@ -1,11 +1,11 @@
 <cfcomponent extends="Driver" implements="IDriver">
 	<cfset fields=array(
-		field("path","path","",true,"Path where the database is or should be located (only Filesystem, virtual Resources like ""ram"" not supported)"),
-		field("mode","mode","MySQL,PostgreSQL,HSQLDB",true,"All database engines behave a little bit different. For certain features, this database can emulate the behavior of specific databases. Not all features or differences of those databases are implemented. Currently, this feature is mainly used for randomized comparative testing","radio")
+		field("Path","path","",true,"Path where the database is or should be located (only Filesystem, virtual Resources like ""ram"" not supported)"),
+		field("Protocol", "protocol", "File,Mem,SSL,TCP,ZIP", true, "Use File, Mem, or ZIP for embedded mode, and TCP or SSL for server mode.", "radio"),
+		field("Additional Paramters", "additional", "", false, "Any additional connection string parameters. Separate multiple values with a semi-colon, e.g. MODE=MSSQLServer;IGNORECASE=TRUE")
 	)>
-	<cfset this.type.host=this.TYPE_HIDDEN>
 	
-	<cfset this.dsn="jdbc:h2:{path}{database};MODE={mode}">
+	<cfset this.dsn="jdbc:h2:{protocol}{host}{path}{database}{additional}">
 	<cfset this.className="org.h2.Driver">
 
 	<cfset SLASH=struct(
@@ -15,15 +15,6 @@
 	
 	
 	<cffunction name="onBeforeUpdate" returntype="void" output="no">
-		<cfset form.custom_path=replace(
-						form.custom_path,
-						SLASH[server.separator.file],
-						server.separator.file,
-						'all')>
-		<cfif right(form.custom_path,1) NEQ server.separator.file>
-			<cfset form.custom_path=form.custom_path&server.separator.file>
-		</cfif>
-		
 		
 		<cfif not directoryExists(form.custom_path)>
 			<cfset var parent=mid(form.custom_path,1,len(form.custom_path)-1)>
@@ -33,6 +24,26 @@
 			<cfelse>
 				<cfthrow message="directory [#form.custom_path#] doesn't exist">
 			</cfif>
+		</cfif>
+		
+		<cfset form.custom_protocol = lcase( form.custom_protocol )>
+		<cfif ( form.custom_protocol == "tcp" ) || ( form.custom_protocol == "ssl" )>
+		
+			<cfset form.custom_protocol &= "://">
+			
+			<cfif right( form.host, 1 ) != "/">
+
+				<cfset form.host &= "/">
+			</cfif>
+		<cfelse>
+		
+			<cfset form.custom_protocol &= ":">
+			<cfset form.host = "">
+		</cfif>
+		
+		<cfif len( form.custom_additional ) && left( form.custom_additional, 1 ) != ';'>
+		
+			<cfset form.custom_additional = ';' & form.custom_additional>
 		</cfif>
 	</cffunction>
 	


### PR DESCRIPTION
please consider the following update which solves JIRA ticket https://issues.jboss.org/browse/RAILO-2006

1) changed the connection string format to allow for the different options listed at http://www.h2database.com/html/features.html#database_url :

```
jdbc:h2:{protocol}{host}{path}{database}{additional}
```

2) removed the Mode as it can be easily added in {additional} if the user chooses to do so.

**a few issues with this update**

1) the main problem is that when I click Edit in the admin (to update an existing datasource) the radio option for the _protocol_ is not preserved, but it looks like the Mode was not preserved either in the current implementation.

2) users who already have a datasource for H2 will see JDBC - Other as the connection string (aka dsn) has changed.

3) the host value should only be used in Server mode, i.e. with TCP or SSL protocol.  the cf-driver ignores the value correctly for other protocols, but I can't change the description just for it as modifying languages/en.xml:settings.dbhostdesc will affect all drivers

I can, however, change it to custom_host or something like that and add description there if this seems to be a major issue.

let me know what you think,

Igal
