### PR TITLE
T2092: ORM: mappedSuperClass inheritance, support for union subclasses (...

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/CFCProxy.java
+++ b/railo-java/railo-core/src/railo/runtime/CFCProxy.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
 
+import railo.runtime.component.Property;
 import railo.runtime.orm.hibernate.tuplizer.proxy.CFCLazyInitializer;
 import railo.runtime.type.cfc.ComponentAccess;
 import railo.runtime.type.cfc.ComponentAccessProxy;
@@ -46,6 +47,10 @@ public class CFCProxy extends ComponentAccessProxy implements HibernateProxy, Se
 	public java.util.Iterator<String> getIterator() {
     	return keysAsStringIterator();
     }
-	
 
+
+	@Override
+	public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties, boolean overrideProperties, boolean inheritedMappedSuperClassOnly) {
+		return li.getCFC().getProperties(onlyPeristent, includeBaseProperties, overrideProperties, inheritedMappedSuperClassOnly);
+	}
 }

--- a/railo-java/railo-core/src/railo/runtime/ComponentImpl.java
+++ b/railo-java/railo-core/src/railo/runtime/ComponentImpl.java
@@ -1922,9 +1922,9 @@ public final class ComponentImpl extends StructSupport implements Externalizable
 		return getProperties(onlyPeristent, false);
 	}
 
-	public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties, boolean overrideProperties, boolean inheritedMappedSuperClassOnly) {
+	public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties, boolean preferBaseProperties, boolean inheritedMappedSuperClassOnly) {
 		Map<String,Property> props=new HashMap<String,Property>();
-		_getProperties(top,props,onlyPeristent, includeBaseProperties, overrideProperties, inheritedMappedSuperClassOnly);
+		_getProperties(top,props,onlyPeristent, includeBaseProperties, preferBaseProperties, inheritedMappedSuperClassOnly);
 		return props.values().toArray(new Property[props.size()]);
 	}
 
@@ -1938,14 +1938,8 @@ public final class ComponentImpl extends StructSupport implements Externalizable
 		_getProperties(c, props, onlyPeristent, includeBaseProperties, true, false);
 	}
 
-	private static void _getProperties(ComponentImpl c,Map<String,Property> props,boolean onlyPeristent, boolean includeBaseProperties, boolean overrideProperties, boolean inheritedMappedSuperClassOnly) {
+	private static void _getProperties(ComponentImpl c,Map<String,Property> props,boolean onlyPeristent, boolean includeBaseProperties, boolean preferBaseProperties, boolean inheritedMappedSuperClassOnly) {
 		//if(c.properties.properties==null) return new Property[0];
-		
-		if(includeBaseProperties && c.base!=null) {
-			if (!inheritedMappedSuperClassOnly || (c.base.properties.meta != null) && Caster.toBooleanValue(c.base.properties.meta.get(KeyConstants._mappedSuperClass, Boolean.FALSE), false)) {
-				_getProperties(c.base, props, onlyPeristent, includeBaseProperties, overrideProperties, inheritedMappedSuperClassOnly);
-			}
-		}
 		
 		// collect with filter
 		if(c.properties.properties!=null){
@@ -1954,12 +1948,20 @@ public final class ComponentImpl extends StructSupport implements Externalizable
 			while(it.hasNext())	{
 				p = it.next().getValue();
 				if(!onlyPeristent || p.isPeristent()) {
-					if (overrideProperties || !props.containsKey(p.getName().toLowerCase())) {
+					if (preferBaseProperties || !props.containsKey(p.getName().toLowerCase())) {
 						props.put(p.getName().toLowerCase(),p);
 					}
 				}
 			}
 		}
+
+		// MZ: Moved to the bottom to allow base properties to override inherited versions
+		if(includeBaseProperties && c.base!=null) {
+			if (!inheritedMappedSuperClassOnly || (c.base.properties.meta != null) && Caster.toBooleanValue(c.base.properties.meta.get(KeyConstants._mappedSuperClass, Boolean.FALSE), false)) {
+				_getProperties(c.base, props, onlyPeristent, includeBaseProperties, preferBaseProperties, inheritedMappedSuperClassOnly);
+			}
+		}
+
 	}
 
 	public ComponentScope getComponentScope() {

--- a/railo-java/railo-core/src/railo/runtime/ComponentImpl.java
+++ b/railo-java/railo-core/src/railo/runtime/ComponentImpl.java
@@ -1935,7 +1935,7 @@ public final class ComponentImpl extends StructSupport implements Externalizable
 	}
 
 	private static void _getProperties(ComponentImpl c,Map<String,Property> props,boolean onlyPeristent, boolean includeBaseProperties) {
-		_getProperties(c, props, onlyPeristent, includeBaseProperties, true, false);
+		_getProperties(c, props, onlyPeristent, includeBaseProperties, false, false);
 	}
 
 	private static void _getProperties(ComponentImpl c,Map<String,Property> props,boolean onlyPeristent, boolean includeBaseProperties, boolean preferBaseProperties, boolean inheritedMappedSuperClassOnly) {
@@ -1948,7 +1948,7 @@ public final class ComponentImpl extends StructSupport implements Externalizable
 			while(it.hasNext())	{
 				p = it.next().getValue();
 				if(!onlyPeristent || p.isPeristent()) {
-					if (preferBaseProperties || !props.containsKey(p.getName().toLowerCase())) {
+					if (!preferBaseProperties || !props.containsKey(p.getName().toLowerCase())) {
 						props.put(p.getName().toLowerCase(),p);
 					}
 				}

--- a/railo-java/railo-core/src/railo/runtime/ComponentImpl.java
+++ b/railo-java/railo-core/src/railo/runtime/ComponentImpl.java
@@ -1922,16 +1922,30 @@ public final class ComponentImpl extends StructSupport implements Externalizable
 		return getProperties(onlyPeristent, false);
 	}
 
+	public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties, boolean overrideProperties, boolean inheritedMappedSuperClassOnly) {
+		Map<String,Property> props=new HashMap<String,Property>();
+		_getProperties(top,props,onlyPeristent, includeBaseProperties, overrideProperties, inheritedMappedSuperClassOnly);
+		return props.values().toArray(new Property[props.size()]);
+	}
+
 	public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties) {
 		Map<String,Property> props=new HashMap<String,Property>();
 		_getProperties(top,props,onlyPeristent, includeBaseProperties);
 		return props.values().toArray(new Property[props.size()]);
 	}
-	
+
 	private static void _getProperties(ComponentImpl c,Map<String,Property> props,boolean onlyPeristent, boolean includeBaseProperties) {
+		_getProperties(c, props, onlyPeristent, includeBaseProperties, true, false);
+	}
+
+	private static void _getProperties(ComponentImpl c,Map<String,Property> props,boolean onlyPeristent, boolean includeBaseProperties, boolean overrideProperties, boolean inheritedMappedSuperClassOnly) {
 		//if(c.properties.properties==null) return new Property[0];
 		
-		if(includeBaseProperties && c.base!=null) _getProperties(c.base, props, onlyPeristent, includeBaseProperties);
+		if(includeBaseProperties && c.base!=null) {
+			if (!inheritedMappedSuperClassOnly || (c.base.properties.meta != null) && Caster.toBooleanValue(c.base.properties.meta.get(KeyConstants._mappedSuperClass, Boolean.FALSE), false)) {
+				_getProperties(c.base, props, onlyPeristent, includeBaseProperties, overrideProperties, inheritedMappedSuperClassOnly);
+			}
+		}
 		
 		// collect with filter
 		if(c.properties.properties!=null){
@@ -1940,7 +1954,9 @@ public final class ComponentImpl extends StructSupport implements Externalizable
 			while(it.hasNext())	{
 				p = it.next().getValue();
 				if(!onlyPeristent || p.isPeristent()) {
-					props.put(p.getName().toLowerCase(),p);
+					if (overrideProperties || !props.containsKey(p.getName().toLowerCase())) {
+						props.put(p.getName().toLowerCase(),p);
+					}
 				}
 			}
 		}

--- a/railo-java/railo-core/src/railo/runtime/ComponentPro.java
+++ b/railo-java/railo-core/src/railo/runtime/ComponentPro.java
@@ -4,4 +4,5 @@ import railo.runtime.component.Property;
 
 public interface ComponentPro extends Component {
 	public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties); 
+	public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties, boolean preferBaseProperties, boolean inheritedMappedSuperClassOnly);
 }

--- a/railo-java/railo-core/src/railo/runtime/ComponentWrap.java
+++ b/railo-java/railo-core/src/railo/runtime/ComponentWrap.java
@@ -467,7 +467,12 @@ public final class ComponentWrap extends StructSupport implements ComponentPro, 
 	public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties) {
 		return ((ComponentPro)component).getProperties(onlyPeristent,includeBaseProperties);
 	}
-	
+
+	@Override
+	public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties, boolean overrideProperties, boolean inheritedMappedSuperClassOnly) {
+		return ((ComponentPro)component).getProperties(onlyPeristent,includeBaseProperties, overrideProperties, inheritedMappedSuperClassOnly);
+	}
+
 	/**
 	 * @see railo.runtime.Component#getComponentScope()
 	 */

--- a/railo-java/railo-core/src/railo/runtime/SuperComponent.java
+++ b/railo-java/railo-core/src/railo/runtime/SuperComponent.java
@@ -611,8 +611,12 @@ public class SuperComponent extends MemberSupport implements ComponentPro, Membe
 	public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties) {
 		return comp.getProperties(onlyPeristent,includeBaseProperties);
 	}
-	
-	
+
+	@Override
+	public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties, boolean overrideProperties, boolean inheritedMappedSuperClassOnly) {
+		return comp.getProperties(onlyPeristent,includeBaseProperties, overrideProperties, inheritedMappedSuperClassOnly);
+	}
+
 
 	/**
 	 * @see railo.runtime.Component#getComponentScope()

--- a/railo-java/railo-core/src/railo/runtime/orm/hibernate/HBMCreator.java
+++ b/railo-java/railo-core/src/railo/runtime/orm/hibernate/HBMCreator.java
@@ -13,6 +13,7 @@ import org.w3c.dom.NodeList;
 
 import railo.commons.lang.StringUtil;
 import railo.runtime.Component;
+import railo.runtime.ComponentPro;
 import railo.runtime.PageContext;
 import railo.runtime.component.Property;
 import railo.runtime.db.DatasourceConnection;
@@ -190,8 +191,8 @@ public class HBMCreator {
 	
 	private static Property[] getProperties(PageContext pc, HibernateORMEngine engine, Component cfci, DatasourceConnection dc, ORMConfiguration ormConf, Struct meta, boolean isClass, boolean recursivePersistentMappedSuperclass) throws ORMException, PageException {
 		Property[] _props;
-		if (recursivePersistentMappedSuperclass) {
-			_props = cfci.getProperties(true, true, false, true);
+		if (recursivePersistentMappedSuperclass && (cfci instanceof ComponentPro)) {
+			_props = ((ComponentPro)cfci).getProperties(true, true, true, true);
 		}
 		else {
 			_props = cfci.getProperties(true);
@@ -203,17 +204,6 @@ public class HBMCreator {
         }
 		return _props;
 	}
-
-
-
-
-
-
-
-
-
-
-
 
 	private static void addId(Component cfc,Document doc, Element clazz, PageContext pc, Struct meta, PropertyCollection propColl, Struct columnsInfo, String tableName, HibernateORMEngine engine) throws PageException {
 		Property[] _ids = getIds(engine,cfc,propColl);

--- a/railo-java/railo-core/src/railo/runtime/orm/hibernate/HibernateSessionFactory.java
+++ b/railo-java/railo-core/src/railo/runtime/orm/hibernate/HibernateSessionFactory.java
@@ -72,8 +72,19 @@ public class HibernateSessionFactory {
 		
 		// dialect
 		DataSource ds = dc.getDatasource();
-		String dialect=Dialect.getDialect(ormConf.getDialect());
-		if(StringUtil.isEmpty(dialect)) dialect=Dialect.getDialect(ds);
+		String dialect=null;
+		try	{
+			if (Class.forName(ormConf.getDialect()) != null) {
+				dialect = ormConf.getDialect();
+			}
+		}
+		catch (Exception e) {
+			// MZ: The dialect value could not be bound to a classname or instantiation causes an exception - ignore and use the default dialect entries
+		}
+		if (dialect == null) {
+			dialect = Dialect.getDialect(ormConf.getDialect());
+			if(StringUtil.isEmpty(dialect)) dialect=Dialect.getDialect(ds);
+		}
 		if(StringUtil.isEmpty(dialect))
 			throw new ORMException(engine,"A valid dialect definition inside the "+Constants.APP_CFC+"/"+Constants.CFAPP_NAME+" is missing. The dialect cannot be determinated automatically");
 		

--- a/railo-java/railo-loader/src/railo/runtime/Component.java
+++ b/railo-java/railo-loader/src/railo/runtime/Component.java
@@ -132,9 +132,6 @@ public interface Component extends Struct,Objects,CFObject {
 	 * @return
 	 */
 	public Property[] getProperties(boolean onlyPeristent);// FUTURE deprecated
-	// FUTURE public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties);
-
-	public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties, boolean overrideProperties, boolean inheritedMappedSuperClassOnly);
 
 	public void setProperty(Property property) throws PageException;
 	

--- a/railo-java/railo-loader/src/railo/runtime/Component.java
+++ b/railo-java/railo-loader/src/railo/runtime/Component.java
@@ -132,8 +132,10 @@ public interface Component extends Struct,Objects,CFObject {
 	 * @return
 	 */
 	public Property[] getProperties(boolean onlyPeristent);// FUTURE deprecated
-	// FUTURE public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties); 
-	
+	// FUTURE public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties);
+
+	public Property[] getProperties(boolean onlyPeristent, boolean includeBaseProperties, boolean overrideProperties, boolean inheritedMappedSuperClassOnly);
+
 	public void setProperty(Property property) throws PageException;
 	
 	public ComponentScope getComponentScope();


### PR DESCRIPTION
- Added a overloaded ComponentImpl.getProperties() method which enabled 2 extra arguments, overrideProperties and inheritedMappedSuperClassOnly
- The ormsetting dialect property now tries to load a custom java class, and if this fails falls back to the original dialect static mappings
