### PR TITLE
Adding a fix for #RAILO-2139

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/functions/math/Round.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/math/Round.java
@@ -3,6 +3,8 @@
  */
 package railo.runtime.functions.math;
 
+import java.math.BigDecimal;
+
 import railo.runtime.PageContext;
 import railo.runtime.ext.function.Function;
 
@@ -10,4 +12,12 @@ public final class Round implements Function {
 	public static double call(PageContext pc , double number) {
 		return StrictMath.round(number);
 	}
+	
+	public static double call(PageContext pc, double number, double precision) {
+		
+		BigDecimal bd = new BigDecimal(Double.toString(number));
+		bd = bd.setScale((int)precision, BigDecimal.ROUND_HALF_UP);
+		return bd.doubleValue();
+	}
+
 }

--- a/railo-java/railo-core/src/resource/fld/web-cfmfunctionlibrary_1_0
+++ b/railo-java/railo-core/src/resource/fld/web-cfmfunctionlibrary_1_0
@@ -13830,7 +13830,15 @@ You can find a list of all available timezones in the Railo administrator (Setti
 			<type>number</type>
 			<required>Yes</required>
 		<description>Number to round </description>
-    </argument>
+    	</argument>
+    	<argument>
+			<name>precision</name>
+			<type>number</type>
+			<required>No</required>
+		<description>Number of decimal points to round to</description>
+    	</argument>
+    
+    
 		<return>
 			<type>number</type>
 		</return>


### PR DESCRIPTION
This is the inital fix for the above ticket. 

The problem at the moment is that the following test case fails:

```
AssertEquals(1.64, round(1.64,2));
```

The error it gives is:

:: Expected [1.6400000000000001] BUT RECEIVED [1.64]. These values should be the same.

You can work around it by adding "" to the expected value as so:
    AssertEquals("1.64", round(1.64,2));
