### PR TITLE
Make CFHTTP handle multipart responses in a more streamlined way (RFC1341). 

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/tag/Http4.java
+++ b/railo-java/railo-core/src/railo/runtime/tag/Http4.java
@@ -72,6 +72,7 @@ import railo.runtime.type.Struct;
 import railo.runtime.type.StructImpl;
 import railo.runtime.type.util.KeyConstants;
 import railo.runtime.util.URLResolver;
+import railo.runtime.util.MultiPartResponseUtils;
 
 // MUST change behavor of mltiple headers now is a array, it das so?
 
@@ -690,7 +691,8 @@ public final class Http4 extends BodyTagImpl implements Http {
 	        	mimetype == null ||  
 	        	mimetype == NO_MIMETYPE || HTTPUtil.isTextMimeType(mimetype);
 	        	
-	        
+		    // is text 
+	        boolean isMultipart= MultiPartResponseUtils.isMultipart(mimetype);        
 	       
 	        cfhttp.set(KeyConstants._text,Caster.toBoolean(isText));
 	        
@@ -794,8 +796,12 @@ public final class Http4 extends BodyTagImpl implements Http {
 		        		throw Caster.toPageException(t);
 					}
 		        }
-		        	
-		        cfhttp.set(FILE_CONTENT,barr);
+		        //IF Multipart response get file content and parse parts
+			    if(isMultipart) {
+			    	cfhttp.set(FILE_CONTENT,MultiPartResponseUtils.getParts(barr,mimetype));
+			    } else {
+			    	cfhttp.set(FILE_CONTENT,barr);
+			    }
 		        
 		        if(file!=null) {
 		        	try {

--- a/railo-java/railo-core/src/railo/runtime/util/MultiPartResponseUtils.java
+++ b/railo-java/railo-core/src/railo/runtime/util/MultiPartResponseUtils.java
@@ -1,0 +1,100 @@
+package railo.runtime.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+
+import org.apache.commons.fileupload.MultipartStream;
+import org.apache.commons.fileupload.MultipartStream.MalformedStreamException;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+
+import railo.commons.io.IOUtil;
+import railo.runtime.exp.ExpressionException;
+import railo.runtime.exp.PageException;
+import railo.runtime.type.Array;
+import railo.runtime.type.ArrayImpl;
+import railo.runtime.type.KeyImpl;
+import railo.runtime.type.StructImpl;
+
+
+public class MultiPartResponseUtils {
+
+	public static boolean isMultipart(String mimetype) {
+		boolean hasBoundary = !extractBoundary(mimetype).equals("");
+		return hasBoundary && mimetype.toLowerCase().startsWith("multipart/");
+	}
+
+	public static Object getParts(byte[] barr,String contentTypeHeader) throws IOException, PageException {
+		
+		String boundary = extractBoundary(contentTypeHeader);
+		ByteArrayInputStream bis = new ByteArrayInputStream(barr);
+		MultipartStream stream;
+		ArrayImpl result = new ArrayImpl();
+		stream = new MultipartStream(bis,getBytes(boundary));
+		
+		boolean hasNextPart;
+
+		hasNextPart = stream.skipPreamble();
+		
+		while (hasNextPart) {
+			result.append(getPartData(stream));
+			hasNextPart = stream.readBoundary();
+		}
+		return result;
+	}
+
+	private static String extractBoundary(String contentTypeHeader) {
+		if (contentTypeHeader == null) return "";
+		String[] headerSections = contentTypeHeader.split(";");
+		for (String section: headerSections) {
+			String[] subHeaderSections = section.split("=");
+			String headerName = subHeaderSections[0];
+			if (headerName.toLowerCase().equals("boundary")) {
+				return subHeaderSections[1];
+			}
+		
+		}
+		return "";
+	}
+
+	private static StructImpl getPartData(MultipartStream stream) throws IOException, PageException {
+		StructImpl headers = extractHeaders(stream.readHeaders());
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		stream.readBodyData(baos);
+		StructImpl fileStruct = new StructImpl();
+		fileStruct.set("content", baos.toByteArray());
+		fileStruct.set("headers", headers);
+		baos.close();
+		return fileStruct;
+	}
+
+	private static StructImpl extractHeaders(String rawHeaders) throws PageException {
+		StructImpl result = new StructImpl();
+		String[] headers = rawHeaders.split("\n");
+		for(String rawHeader :headers) {
+			String[] headerArray = rawHeader.split(":");
+			String headerName = headerArray[0];
+			if (!headerName.trim().equals("")) {
+				String value = StringUtils.join(Arrays.copyOfRange(headerArray, 1, headerArray.length),":").trim();
+				result.set(headerName, value.trim());
+			}
+		}
+		return result;
+	}
+
+	private static byte[] getBytes(String string) {
+		byte[] bytes;
+		try {
+			bytes = string.getBytes("UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			bytes = string.getBytes();
+		}
+		return bytes;
+	}
+
+
+}


### PR DESCRIPTION
This implementation will return an array of structs in cfhttp.filecontent. each element in the array is a struct with a 'headers' key and a 'content' key. if a response has a content type of multipart/*, then the contents will be attempted to be parsed as multipart content.  

NOTE: this is not talking about multipart requests.

If you think it rocks, then please pull it in. I am open to changes. I thought that maybe another key on cfhttp might be more compatible. i.e. instead of using cfhttp.filecontent use cfhttp.parts.
