### PR TITLE
this.sessionClusterKey

### DIFF
--- a/railo-cfml/compileAdmin.cfm
+++ b/railo-cfml/compileAdmin.cfm
@@ -1,0 +1,31 @@
+<cfsetting showdebugoutput="No" enablecfoutputonly="Yes">
+
+<cftry>
+
+	<cfadmin 
+		action="updateMapping"
+		type="web"
+		password="#url.password#"
+		archive=""
+		primary="physical"
+		trusted="false"
+		virtual="/railo-context-compiled"
+		physical="#url.admin_source#"
+		remoteClients="">
+	
+	<cfadmin 
+		action="createArchive"
+		type="web"
+		password="#url.password#"
+		file="#url.admin_source#/railo-context.ra"
+		virtual="/railo-context-compiled"
+		secure="true"
+		append="false"
+		remoteClients="">
+	<cfcatch type="Any">
+		<cfoutput>Mapping not created. Error occured. (#cfcatch.message#)</cfoutput>
+		<cfabort>
+	</cfcatch>
+</cftry>
+<cfoutput>Railo Admin compiled...</cfoutput>
+

--- a/railo-java/railo-core/.externalToolBuilders/Railo.launch
+++ b/railo-java/railo-core/.externalToolBuilders/Railo.launch
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.ant.AntBuilderLaunchConfigurationType">
+<stringAttribute key="org.eclipse.ant.ui.ATTR_ANT_MANUAL_TARGETS" value="deploy,"/>
+<booleanAttribute key="org.eclipse.ant.ui.ATTR_TARGETS_UPDATED" value="true"/>
+<booleanAttribute key="org.eclipse.ant.ui.DEFAULT_VM_INSTALL" value="true"/>
+<booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="false"/>
+<stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.ant.ui.AntClasspathProvider"/>
+<booleanAttribute key="org.eclipse.jdt.launching.DEFAULT_CLASSPATH" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/jdk1.6.0_37"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.ant.internal.launching.remote.InternalAntRunner"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="Railo-Core"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc:/Railo-Core/build.xml}"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS" value="full,incremental,"/>
+<booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.ant.ui.remoteAntProcessFactory"/>
+</launchConfiguration>

--- a/railo-java/railo-core/.project
+++ b/railo-java/railo-core/.project
@@ -10,6 +10,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+				<dictionary>
+					<key>LaunchConfigHandle</key>
+					<value>&lt;project&gt;/.externalToolBuilders/Railo.launch</value>
+				</dictionary>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>

--- a/railo-java/railo-core/build.xml
+++ b/railo-java/railo-core/build.xml
@@ -10,6 +10,17 @@
 		<fileset dir="${lib.dir}"/>
 	</path>
 	
+	<!-- service starting -->
+    <macrodef name="service">
+        <attribute name="service"/>
+        <attribute name="action"/>
+        <sequential>
+            <exec executable="cmd.exe">
+                <arg line="/c net @{action} '@{service}'"/>
+            </exec>
+         </sequential>
+    </macrodef>
+	
 	<!-- ================================= 
           target: getInfo
 		  This target extracts the version name for the rc file from the INI file                        
@@ -19,7 +30,7 @@
     	<loadfile property="core.version" srcFile="src/railo/runtime/Info.ini">
 			<filterchain>
 				<linecontainsregexp>
-					<regexp pattern="number=[0-3]+.[0-9]+.[0-9]+.[0-9]+"/>
+					<regexp pattern="number=[0-4]+.[0-9]+.[0-9]+.[0-9]+"/>
 				</linecontainsregexp>
 				<replacetokens begintoken="n" endtoken="=">
 					<token key="umber" value=""/>
@@ -66,10 +77,11 @@
     	
     	<property name="railo.admin_source_abs" location="${railo.admin_source}"/>
     	
-    	<input message="Please enter Railo-Admin password:" addproperty="railo.password" defaultvalue="your admin password"/>
+    	<!--<input message="Please enter Railo-Admin password:" addproperty="railo.password" defaultvalue="your admin password"/>
+    	-->
 		<echo>Compiling Railo Administrator</echo>
     	<!-- please note, that you have to set the railo.admin_source location in the properties file -->
-		<get src="${railo.url}?password=${railo.password}&amp;admin_source=${railo.admin_source_abs}" verbose="on" dest="generate.html"/>
+		<get src="${railo.url}?password=sysadmin&amp;admin_source=${railo.admin_source_abs}" verbose="on" dest="generate.html"/>
     	<loadfile property="railo.compile_message" srcFile="generate.html" />
 		<echo>Message from Railo: ${railo.compile_message}</echo>
     	<echo>Admin compiled to: ${railo.admin_source_abs}/railo-context.ra</echo>
@@ -123,4 +135,11 @@
     	</copy>
     </target>
 
+    <target name="deploy" depends="install" description="Deploys the .rc file and restarts MasterControl">
+        <echo>Deploy ${core.version}.rc and restart MasterControlEMS</echo>
+    	<copy todir="C:\files\sites\11\server\railo\railo-server\patches" file="${dist.dir}/${core.version}.rc"/>
+    	<service action="stop" service="MasterControlEMS"/>
+    	<service action="start" service="MasterControlEMS"/>
+    </target>
+	
 </project>

--- a/railo-java/railo-core/build.xml
+++ b/railo-java/railo-core/build.xml
@@ -79,9 +79,11 @@
     	
     	<!--<input message="Please enter Railo-Admin password:" addproperty="railo.password" defaultvalue="your admin password"/>
     	-->
+    	<service action="start" service="Railo4Compiler"/>
 		<echo>Compiling Railo Administrator</echo>
     	<!-- please note, that you have to set the railo.admin_source location in the properties file -->
 		<get src="${railo.url}?password=sysadmin&amp;admin_source=${railo.admin_source_abs}" verbose="on" dest="generate.html"/>
+    	<service action="stop" service="Railo4Compiler"/>
     	<loadfile property="railo.compile_message" srcFile="generate.html" />
 		<echo>Message from Railo: ${railo.compile_message}</echo>
     	<echo>Admin compiled to: ${railo.admin_source_abs}/railo-context.ra</echo>

--- a/railo-java/railo-core/build.xml
+++ b/railo-java/railo-core/build.xml
@@ -80,6 +80,7 @@
     	<!--<input message="Please enter Railo-Admin password:" addproperty="railo.password" defaultvalue="your admin password"/>
     	-->
     	<service action="start" service="Railo4Compiler"/>
+    	<sleep seconds="7" />
 		<echo>Compiling Railo Administrator</echo>
     	<!-- please note, that you have to set the railo.admin_source location in the properties file -->
 		<get src="${railo.url}?password=sysadmin&amp;admin_source=${railo.admin_source_abs}" verbose="on" dest="generate.html"/>

--- a/railo-java/railo-core/src/mastercontrol/file/InputStreamResource.java
+++ b/railo-java/railo-core/src/mastercontrol/file/InputStreamResource.java
@@ -1,0 +1,98 @@
+package mastercontrol.file;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import railo.commons.io.res.Resource;
+import railo.commons.io.res.ResourceProvider;
+
+public class InputStreamResource extends railo.commons.io.res.util.ReadOnlyResourceSupport{
+
+	private static final long serialVersionUID = 1L;
+	private String fileName;
+	private long size;
+	private InputStream stream;
+	private long date;
+	public InputStreamResource(String fileName,long size,InputStream stream) {
+		this.fileName = fileName;
+		this.size = size;
+		this.stream = stream;
+		this.date = System.currentTimeMillis();
+	}
+	
+	@Override
+	public boolean isReadable() {
+		return true;
+	}
+
+	@Override
+	public boolean exists() {
+		return false;
+	}
+
+	@Override
+	public String getName() {
+		return this.fileName;
+	}
+
+	@Override
+	public String getParent() {
+		return null;
+	}
+
+	@Override
+	public Resource getParentResource() {
+		return null;
+	}
+
+	@Override
+	public Resource getRealResource(String realpath) {
+		return null;
+	}
+
+	@Override
+	public String getPath() {
+		return null;
+	}
+
+	@Override
+	public boolean isAbsolute() {
+		return false;
+	}
+
+	@Override
+	public boolean isDirectory() {
+		return false;
+	}
+
+	@Override
+	public boolean isFile() {
+		return true;
+	}
+
+	@Override
+	public long lastModified() {
+		return this.date;
+	}
+
+	@Override
+	public long length() {
+		return size;
+	}
+
+	@Override
+	public Resource[] listResources() {
+		return new Resource[0];
+	}
+
+	@Override
+	public InputStream getInputStream() throws IOException {
+		return stream;
+	}
+
+	@Override
+	public ResourceProvider getResourceProvider() {
+		return null;
+	}
+
+}

--- a/railo-java/railo-core/src/railo/runtime/Info.ini
+++ b/railo-java/railo-core/src/railo/runtime/Info.ini
@@ -2,6 +2,6 @@
 number=4.0.1.004
 level=os
 state=beta
-name=Appollo
-name-explanation=http://en.wikipedia.org/wiki/Appollo_(dog)
+name=Railo-MasterControl
+name-explanation=https://github.com/clitnak/mcrailo
 release-date=2012/10/15 01:28:00 CET

--- a/railo-java/railo-core/src/railo/runtime/functions/system/GetApplicationSettings.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/system/GetApplicationSettings.java
@@ -66,6 +66,7 @@ public class GetApplicationSettings {
 
 		sct.setEL("clientCluster", Caster.toBoolean(ac.getClientCluster()));
 		sct.setEL("sessionCluster", Caster.toBoolean(ac.getSessionCluster()));
+		sct.setEL("sessionClusterKey", Caster.toString(ac.getSessionClusterKey()));
 		
 
 		sct.setEL("invokeImplicitAccessor", Caster.toBoolean(ac.getTriggerComponentDataMember()));

--- a/railo-java/railo-core/src/railo/runtime/listener/ClassicApplicationContext.java
+++ b/railo-java/railo-core/src/railo/runtime/listener/ClassicApplicationContext.java
@@ -26,6 +26,7 @@ public class ClassicApplicationContext extends ApplicationContextSupport {
 	private static final long serialVersionUID = 940663152793150953L;
 
 	private String name;
+	private String sessionClusterKey;
     private boolean setClientCookies;
     private boolean setDomainCookies;
     private boolean setSessionManagement;
@@ -446,6 +447,11 @@ public class ClassicApplicationContext extends ApplicationContextSupport {
 	public void setSessionCluster(boolean sessionCluster) {
 		this.sessionCluster = sessionCluster;
 	}
+	
+	
+	public void setSessionClusterKey(String key) {
+		this.sessionClusterKey = key;
+	}
 
 
 	/**
@@ -488,6 +494,12 @@ public class ClassicApplicationContext extends ApplicationContextSupport {
 	@Override
 	public boolean getTriggerComponentDataMember() {
 		return triggerComponentDataMember;
+	}
+
+	public String getSessionClusterKey() {
+		if(this.sessionClusterKey == null)
+			return this.name;
+		return this.sessionClusterKey;
 	}
 
 	@Override

--- a/railo-java/railo-core/src/railo/runtime/listener/ModernApplicationContext.java
+++ b/railo-java/railo-core/src/railo/runtime/listener/ModernApplicationContext.java
@@ -61,6 +61,7 @@ public class ModernApplicationContext extends ApplicationContextSupport {
 	private static final Collection.Key SECURE_JSON = KeyImpl.intern("secureJson");
 	private static final Collection.Key LOCAL_MODE = KeyImpl.intern("localMode");
 	private static final Collection.Key SESSION_CLUSTER = KeyImpl.intern("sessionCluster");
+	private static final Collection.Key SESSION_CLUSTER_KEY = KeyImpl.intern("sessionClusterKey");
 	private static final Collection.Key CLIENT_CLUSTER = KeyImpl.intern("clientCluster");
 	
 
@@ -95,6 +96,7 @@ public class ModernApplicationContext extends ApplicationContextSupport {
 
 	private String clientStorage;
 	private String sessionStorage;
+	private String sessionClusterKey;
 	private String secureJsonPrefix="//";
 	private boolean secureJson; 
 	private Mapping[] mappings;
@@ -118,6 +120,7 @@ public class ModernApplicationContext extends ApplicationContextSupport {
 	private boolean initSecureJson;
 	private boolean initSessionStorage;
 	private boolean initSessionCluster;
+	private boolean initSessionClusterKey;
 	private boolean initClientCluster;
 	private boolean initLoginStorage;
 	private boolean initSessionType;
@@ -408,6 +411,14 @@ public class ModernApplicationContext extends ApplicationContextSupport {
 		return sessionCluster;
 	}
 
+	public String getSessionClusterKey() {
+		if(!initSessionClusterKey) {
+			Object o = get(component,SESSION_CLUSTER_KEY,getName());
+			if(o!=null) sessionClusterKey=Caster.toString(o,sessionClusterKey);
+			initSessionClusterKey=true;
+		}
+		return sessionClusterKey;
+	}
 	/**
 	 * @see railo.runtime.listener.ApplicationContext#getClientCluster()
 	 */
@@ -790,7 +801,11 @@ public class ModernApplicationContext extends ApplicationContextSupport {
 		this.sessionCluster=sessionCluster;
 	}
 
-	@Override
+	public void setSessionClusterKey(String sessionClusterKey) {
+		this.sessionClusterKey = sessionClusterKey;
+		this.initSessionClusterKey =true;
+	}
+
 	public void setS3(Properties s3) {
 		initS3=true;
 		this.s3=s3;

--- a/railo-java/railo-core/src/railo/runtime/tag/Admin.java
+++ b/railo-java/railo-core/src/railo/runtime/tag/Admin.java
@@ -244,7 +244,9 @@ public final class Admin extends TagImpl implements DynamicAttributes {
     public int doStartTag() throws PageException {
     	//adminSync = pageContext.getAdminSync();
     	
-
+    	// Type
+        type=toType(getString("admin",action,"type"),true);
+    	
         config=(ConfigImpl)pageContext.getConfig();
         if(type==TYPE_SERVER)
             config=(ConfigImpl)config.getConfigServer(password);
@@ -278,9 +280,6 @@ public final class Admin extends TagImpl implements DynamicAttributes {
         	doGetLoginSettings();
             return SKIP_BODY;
         }
-        
-        // Type
-        type=toType(getString("admin",action,"type"),true);
         
         // has Password
         if(action.equals("haspassword")) {

--- a/railo-java/railo-core/src/railo/runtime/tag/Admin.java
+++ b/railo-java/railo-core/src/railo/runtime/tag/Admin.java
@@ -247,6 +247,14 @@ public final class Admin extends TagImpl implements DynamicAttributes {
     	// Type
         type=toType(getString("admin",action,"type"),true);
     	
+        try {
+            // Password
+            password = getString("password","");
+        } 
+        catch (Exception e) {
+            throw Caster.toPageException(e);
+        }
+        
         config=(ConfigImpl)pageContext.getConfig();
         if(type==TYPE_SERVER)
             config=(ConfigImpl)config.getConfigServer(password);
@@ -308,11 +316,6 @@ public final class Admin extends TagImpl implements DynamicAttributes {
         try {
             // Password
             password = getString("password","");
-            /* Config
-            config=(ConfigImpl)pageContext.getConfig();
-            if(type==TYPE_SERVER)
-                config=(ConfigImpl)config.getConfigServer(password);
-            */
             adminSync = config.getAdminSync();
         	admin = ConfigWebAdmin.newInstance(config,password);
         } 

--- a/railo-java/railo-core/src/railo/runtime/tag/Http4.java
+++ b/railo-java/railo-core/src/railo/runtime/tag/Http4.java
@@ -72,6 +72,7 @@ import railo.runtime.type.Struct;
 import railo.runtime.type.StructImpl;
 import railo.runtime.type.util.KeyConstants;
 import railo.runtime.util.URLResolver;
+import railo.runtime.util.MultiPartResponseUtils;
 
 // MUST change behavor of mltiple headers now is a array, it das so?
 
@@ -690,7 +691,8 @@ public final class Http4 extends BodyTagImpl implements Http {
 	        	mimetype == null ||  
 	        	mimetype == NO_MIMETYPE || HTTPUtil.isTextMimeType(mimetype);
 	        	
-	        
+		    // is text 
+	        boolean isMultipart= MultiPartResponseUtils.isMultipart(mimetype);        
 	       
 	        cfhttp.set(KeyConstants._text,Caster.toBoolean(isText));
 	        
@@ -794,8 +796,12 @@ public final class Http4 extends BodyTagImpl implements Http {
 		        		throw Caster.toPageException(t);
 					}
 		        }
-		        	
-		        cfhttp.set(FILE_CONTENT,barr);
+		        //IF Multipart response get file content and parse parts
+			    if(isMultipart) {
+			    	cfhttp.set(FILE_CONTENT,MultiPartResponseUtils.getParts(barr,mimetype));
+			    } else {
+			    	cfhttp.set(FILE_CONTENT,barr);
+			    }
 		        
 		        if(file!=null) {
 		        	try {

--- a/railo-java/railo-core/src/railo/runtime/type/scope/ScopeContext.java
+++ b/railo-java/railo-core/src/railo/runtime/type/scope/ScopeContext.java
@@ -460,7 +460,7 @@ public final class ScopeContext {
 					if(ds!=null && ds.isStorage()){
 						if(SessionDatasource.hasInstance(storage,pc)) return true;
 					}
-					return  SessionCache.hasInstance(storage,appContext.getName(),pc);
+					return  SessionCache.hasInstance(storage,appContext.getSessionClusterKey(),pc);
 				}
 			}
 			return true;
@@ -515,7 +515,7 @@ public final class ScopeContext {
 				else{
 					DataSourceImpl ds = (DataSourceImpl) ((ConfigImpl)pc.getConfig()).getDataSource(storage,null);
 					if(ds!=null && ds.isStorage())session=SessionDatasource.getInstance(storage,pc,getLog(),null);
-					else session=SessionCache.getInstance(storage,appContext.getName(),pc,getLog(),null);
+					else session=SessionCache.getInstance(storage,appContext.getSessionClusterKey(),pc,getLog(),null);
 					
 					if(session==null){
 						// datasource not enabled for storage

--- a/railo-java/railo-core/src/railo/runtime/type/scope/storage/StorageScopeCache.java
+++ b/railo-java/railo-core/src/railo/runtime/type/scope/storage/StorageScopeCache.java
@@ -105,7 +105,9 @@ public abstract class StorageScopeCache extends StorageScopeImpl {
 		Cache cache = getCache(pc.getConfig(),cacheName);
 		String key=getKey(pc.getCFID(),appName,strType);
 		
-		Struct s = (Struct) cache.getValue(key,null);
+		Object o = cache.getValue(key,null);
+		Struct s = null;
+		if (o instanceof Struct) s = (Struct) o;
 		
 		if(s!=null)
 			ScopeContext.info(log,"load existing data from  cache ["+cacheName+"] to create "+strType+" scope for "+pc.getApplicationContext().getName()+"/"+pc.getCFID());

--- a/railo-java/railo-core/src/railo/runtime/type/scope/storage/StorageScopeImpl.java
+++ b/railo-java/railo-core/src/railo/runtime/type/scope/storage/StorageScopeImpl.java
@@ -141,7 +141,7 @@ public abstract class StorageScopeImpl extends StructSupport implements StorageS
 			sct.setEL(HITCOUNT, new Double(hitcount++));
 		}
 		else {
-			sct.setEL(SESSION_ID, pc.getApplicationContext().getName()+"_"+pc.getCFID()+"_"+pc.getCFToken());
+			sct.setEL(SESSION_ID, pc.getApplicationContext().getSessionClusterKey()+"_"+pc.getCFID()+"_"+pc.getCFToken());
 		}
 		sct.setEL(TIMECREATED, timecreated);
 	}

--- a/railo-java/railo-core/src/railo/runtime/util/MultiPartResponseUtils.java
+++ b/railo-java/railo-core/src/railo/runtime/util/MultiPartResponseUtils.java
@@ -1,0 +1,100 @@
+package railo.runtime.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+
+import org.apache.commons.fileupload.MultipartStream;
+import org.apache.commons.fileupload.MultipartStream.MalformedStreamException;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+
+import railo.commons.io.IOUtil;
+import railo.runtime.exp.ExpressionException;
+import railo.runtime.exp.PageException;
+import railo.runtime.type.Array;
+import railo.runtime.type.ArrayImpl;
+import railo.runtime.type.KeyImpl;
+import railo.runtime.type.StructImpl;
+
+
+public class MultiPartResponseUtils {
+
+	public static boolean isMultipart(String mimetype) {
+		boolean hasBoundary = !extractBoundary(mimetype).equals("");
+		return hasBoundary && mimetype.toLowerCase().startsWith("multipart/");
+	}
+
+	public static Object getParts(byte[] barr,String contentTypeHeader) throws IOException, PageException {
+		
+		String boundary = extractBoundary(contentTypeHeader);
+		ByteArrayInputStream bis = new ByteArrayInputStream(barr);
+		MultipartStream stream;
+		ArrayImpl result = new ArrayImpl();
+		stream = new MultipartStream(bis,getBytes(boundary));
+		
+		boolean hasNextPart;
+
+		hasNextPart = stream.skipPreamble();
+		
+		while (hasNextPart) {
+			result.append(getPartData(stream));
+			hasNextPart = stream.readBoundary();
+		}
+		return result;
+	}
+
+	private static String extractBoundary(String contentTypeHeader) {
+		if (contentTypeHeader == null) return "";
+		String[] headerSections = contentTypeHeader.split(";");
+		for (String section: headerSections) {
+			String[] subHeaderSections = section.split("=");
+			String headerName = subHeaderSections[0];
+			if (headerName.toLowerCase().equals("boundary")) {
+				return subHeaderSections[1];
+			}
+		
+		}
+		return "";
+	}
+
+	private static StructImpl getPartData(MultipartStream stream) throws IOException, PageException {
+		StructImpl headers = extractHeaders(stream.readHeaders());
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		stream.readBodyData(baos);
+		StructImpl fileStruct = new StructImpl();
+		fileStruct.set("content", baos.toByteArray());
+		fileStruct.set("headers", headers);
+		baos.close();
+		return fileStruct;
+	}
+
+	private static StructImpl extractHeaders(String rawHeaders) throws PageException {
+		StructImpl result = new StructImpl();
+		String[] headers = rawHeaders.split("\n");
+		for(String rawHeader :headers) {
+			String[] headerArray = rawHeader.split(":");
+			String headerName = headerArray[0];
+			if (!headerName.trim().equals("")) {
+				String value = StringUtils.join(Arrays.copyOfRange(headerArray, 1, headerArray.length),":").trim();
+				result.set(headerName, value.trim());
+			}
+		}
+		return result;
+	}
+
+	private static byte[] getBytes(String string) {
+		byte[] bytes;
+		try {
+			bytes = string.getBytes("UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			bytes = string.getBytes();
+		}
+		return bytes;
+	}
+
+
+}

--- a/railo-java/railo-core/src/resource/context/admin/plugin/NoteTab/overview.cfm
+++ b/railo-java/railo-core/src/resource/context/admin/plugin/NoteTab/overview.cfm
@@ -10,7 +10,7 @@
 	</tr>
 	</table>
 	<br />
-	<input class="submit" type="submit" name="submit" value="#lang.btnSubmit#" />
+	<input class="button submit" type="submit" name="submit" value="#lang.btnSubmit#" />
 </form>
 	
 </cfoutput>

--- a/railo-java/railo-core/src/resource/context/admin/plugin/Resource/overview.cfm
+++ b/railo-java/railo-core/src/resource/context/admin/plugin/Resource/overview.cfm
@@ -4,7 +4,7 @@
 function selectAll(field) {
 	var form=field.form;
 	for(var key in form.elements){
-		if((form.elements[key] && ""+form.elements[key].name).indexOf("path")==0){
+		if(form.elements[key] && (""+form.elements[key].name).indexOf("path")==0){
 			form.elements[key].checked=field.checked;
 		}
 	}
@@ -16,15 +16,15 @@ function selectAll(field) {
 <table class="tbl">
 <tr>
     <td valign="top" class="tblHead">#lang.size#</td>
-    <td valign="top" class="tblContent">#req.dspSize#</td>
+    <td valign="top">#req.dspSize#</td>
 </tr>
 <tr>
     <td valign="top" class="tblHead">#lang.countDir#</td>
-    <td valign="top" class="tblContent">#req.countDir#</td>
+    <td valign="top">#req.countDir#</td>
 </tr>
 <tr>
     <td valign="top" class="tblHead">#lang.countFile#</td>
-    <td valign="top" class="tblContent">#req.countFile#</td>
+    <td valign="top">#req.countFile#</td>
 </tr>
 </table>
 <br />
@@ -32,7 +32,7 @@ function selectAll(field) {
 <h2>#lang.listing#</h2>
 #lang.descListing#<br /><br />
 <table class="tbl">
-<cfform action="#action('delete')#" method="post">
+<cfform onerror="customError" action="#action('delete')#" method="post">
     <tr>
         <td width="20"><input type="checkbox" class="checkbox" name="rowreadonly" onclick="selectAll(this)">
             </td>
@@ -52,9 +52,9 @@ function selectAll(field) {
         </tr>
         </table>
         </td>
-        <td class="tblContent" nowrap>#req.listing.path#</td>
-        <td class="tblContent" nowrap>#req.listing.dspSize#</td>
-        <td class="tblContent" nowrap>#dateFormat(req.listing.dateLastModified)# #TimeFormat(req.listing.dateLastModified)#</td>
+        <td nowrap>#req.listing.path#</td>
+        <td nowrap>#req.listing.dspSize#</td>
+        <td nowrap>#dateFormat(req.listing.dateLastModified)# #TimeFormat(req.listing.dateLastModified)#</td>
     </tr>
     </cfloop>
     <tr>
@@ -69,7 +69,7 @@ function selectAll(field) {
             <td></td>
             <td valign="top"><cfmodule template="/railo-context/admin/img.cfm" src="#request.adminType#-bgcolor.gif" width="1" height="14"><cfmodule template="/railo-context/admin/img.cfm" src="#request.adminType#-bgcolor.gif" width="36" height="1"></td>
              <td>&nbsp;
-            <input type="submit" class="submit" name="delete" value="#lang.btnDelete#">
+            <input type="submit" class="button submit" name="delete" value="#lang.btnDelete#">
             </td>	
         </tr>
          </table>

--- a/railo-java/railo-loader/src/railo/runtime/listener/ApplicationContext.java
+++ b/railo-java/railo-loader/src/railo/runtime/listener/ApplicationContext.java
@@ -106,8 +106,10 @@ public interface ApplicationContext extends Serializable {
 	public TimeSpan getClientTimeout();
 	
 	public short getSessionType();
-	
+
 	public boolean getSessionCluster();
+	
+	public String getSessionClusterKey();
 
 	public boolean getClientCluster();
 
@@ -140,6 +142,7 @@ public interface ApplicationContext extends Serializable {
 	public void setSessionType(short sessionType);
 	public void setClientCluster(boolean clientCluster);
 	public void setSessionCluster(boolean sessionCluster);
+	public void setSessionClusterKey(String key);
 	public void setS3(Properties s3);
 	public void setORMEnabled(boolean ormenabled);
 	public void setORMConfiguration(ORMConfiguration ormConf);


### PR DESCRIPTION
when using this.sessionCluster = true and a shared session cache, it uses the application name as part of the storage key, so two applications with different names do not share the same storage. I realize that most of the time two instances of the same application (with the same name) will use the same storage, We have need of having two instances of the same application in the same JVM. Interestingly, we don't want them to share application scope variables, but we do want them to share session storage. This is mostly for testing environments (pretending to do load balancing and failover in the same JVM)

This implements a way for this to happen.

this.sessionClusterKey = "MyKey"

If you set that to be the same for two applications instances but with different application names, they will share the session storage but will have two different applications, thus mimicking two identacl but separate application instances in the same jvm but sharing sessions.
