### PR TITLE
Pull attempt #2 For this.sessionClusterKey :)

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/functions/system/GetApplicationSettings.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/system/GetApplicationSettings.java
@@ -66,6 +66,7 @@ public class GetApplicationSettings {
 
 		sct.setEL("clientCluster", Caster.toBoolean(ac.getClientCluster()));
 		sct.setEL("sessionCluster", Caster.toBoolean(ac.getSessionCluster()));
+		sct.setEL("sessionClusterKey", Caster.toString(ac.getSessionClusterKey()));
 		
 
 		sct.setEL("invokeImplicitAccessor", Caster.toBoolean(ac.getTriggerComponentDataMember()));

--- a/railo-java/railo-core/src/railo/runtime/listener/ClassicApplicationContext.java
+++ b/railo-java/railo-core/src/railo/runtime/listener/ClassicApplicationContext.java
@@ -26,6 +26,7 @@ public class ClassicApplicationContext extends ApplicationContextSupport {
 	private static final long serialVersionUID = 940663152793150953L;
 
 	private String name;
+	private String sessionClusterKey;
     private boolean setClientCookies;
     private boolean setDomainCookies;
     private boolean setSessionManagement;
@@ -446,6 +447,11 @@ public class ClassicApplicationContext extends ApplicationContextSupport {
 	public void setSessionCluster(boolean sessionCluster) {
 		this.sessionCluster = sessionCluster;
 	}
+	
+	
+	public void setSessionClusterKey(String key) {
+		this.sessionClusterKey = key;
+	}
 
 
 	/**
@@ -488,6 +494,12 @@ public class ClassicApplicationContext extends ApplicationContextSupport {
 	@Override
 	public boolean getTriggerComponentDataMember() {
 		return triggerComponentDataMember;
+	}
+
+	public String getSessionClusterKey() {
+		if(this.sessionClusterKey == null)
+			return this.name;
+		return this.sessionClusterKey;
 	}
 
 	@Override

--- a/railo-java/railo-core/src/railo/runtime/listener/ModernApplicationContext.java
+++ b/railo-java/railo-core/src/railo/runtime/listener/ModernApplicationContext.java
@@ -61,6 +61,7 @@ public class ModernApplicationContext extends ApplicationContextSupport {
 	private static final Collection.Key SECURE_JSON = KeyImpl.intern("secureJson");
 	private static final Collection.Key LOCAL_MODE = KeyImpl.intern("localMode");
 	private static final Collection.Key SESSION_CLUSTER = KeyImpl.intern("sessionCluster");
+	private static final Collection.Key SESSION_CLUSTER_KEY = KeyImpl.intern("sessionClusterKey");
 	private static final Collection.Key CLIENT_CLUSTER = KeyImpl.intern("clientCluster");
 	
 
@@ -95,6 +96,7 @@ public class ModernApplicationContext extends ApplicationContextSupport {
 
 	private String clientStorage;
 	private String sessionStorage;
+	private String sessionClusterKey;
 	private String secureJsonPrefix="//";
 	private boolean secureJson; 
 	private Mapping[] mappings;
@@ -118,6 +120,7 @@ public class ModernApplicationContext extends ApplicationContextSupport {
 	private boolean initSecureJson;
 	private boolean initSessionStorage;
 	private boolean initSessionCluster;
+	private boolean initSessionClusterKey;
 	private boolean initClientCluster;
 	private boolean initLoginStorage;
 	private boolean initSessionType;
@@ -408,6 +411,14 @@ public class ModernApplicationContext extends ApplicationContextSupport {
 		return sessionCluster;
 	}
 
+	public String getSessionClusterKey() {
+		if(!initSessionClusterKey) {
+			Object o = get(component,SESSION_CLUSTER_KEY,getName());
+			if(o!=null) sessionClusterKey=Caster.toString(o,sessionClusterKey);
+			initSessionClusterKey=true;
+		}
+		return sessionClusterKey;
+	}
 	/**
 	 * @see railo.runtime.listener.ApplicationContext#getClientCluster()
 	 */
@@ -790,7 +801,11 @@ public class ModernApplicationContext extends ApplicationContextSupport {
 		this.sessionCluster=sessionCluster;
 	}
 
-	@Override
+	public void setSessionClusterKey(String sessionClusterKey) {
+		this.sessionClusterKey = sessionClusterKey;
+		this.initSessionClusterKey =true;
+	}
+
 	public void setS3(Properties s3) {
 		initS3=true;
 		this.s3=s3;

--- a/railo-java/railo-core/src/railo/runtime/type/scope/ScopeContext.java
+++ b/railo-java/railo-core/src/railo/runtime/type/scope/ScopeContext.java
@@ -460,7 +460,7 @@ public final class ScopeContext {
 					if(ds!=null && ds.isStorage()){
 						if(SessionDatasource.hasInstance(storage,pc)) return true;
 					}
-					return  SessionCache.hasInstance(storage,appContext.getName(),pc);
+					return  SessionCache.hasInstance(storage,appContext.getSessionClusterKey(),pc);
 				}
 			}
 			return true;
@@ -515,7 +515,7 @@ public final class ScopeContext {
 				else{
 					DataSourceImpl ds = (DataSourceImpl) ((ConfigImpl)pc.getConfig()).getDataSource(storage,null);
 					if(ds!=null && ds.isStorage())session=SessionDatasource.getInstance(storage,pc,getLog(),null);
-					else session=SessionCache.getInstance(storage,appContext.getName(),pc,getLog(),null);
+					else session=SessionCache.getInstance(storage,appContext.getSessionClusterKey(),pc,getLog(),null);
 					
 					if(session==null){
 						// datasource not enabled for storage

--- a/railo-java/railo-core/src/railo/runtime/type/scope/storage/StorageScopeCache.java
+++ b/railo-java/railo-core/src/railo/runtime/type/scope/storage/StorageScopeCache.java
@@ -105,7 +105,9 @@ public abstract class StorageScopeCache extends StorageScopeImpl {
 		Cache cache = getCache(pc.getConfig(),cacheName);
 		String key=getKey(pc.getCFID(),appName,strType);
 		
-		Struct s = (Struct) cache.getValue(key,null);
+		Object o = cache.getValue(key,null);
+		Struct s = null;
+		if (o instanceof Struct) s = (Struct) o;
 		
 		if(s!=null)
 			ScopeContext.info(log,"load existing data from  cache ["+cacheName+"] to create "+strType+" scope for "+pc.getApplicationContext().getName()+"/"+pc.getCFID());

--- a/railo-java/railo-core/src/railo/runtime/type/scope/storage/StorageScopeImpl.java
+++ b/railo-java/railo-core/src/railo/runtime/type/scope/storage/StorageScopeImpl.java
@@ -141,7 +141,7 @@ public abstract class StorageScopeImpl extends StructSupport implements StorageS
 			sct.setEL(HITCOUNT, new Double(hitcount++));
 		}
 		else {
-			sct.setEL(SESSION_ID, pc.getApplicationContext().getName()+"_"+pc.getCFID()+"_"+pc.getCFToken());
+			sct.setEL(SESSION_ID, pc.getApplicationContext().getSessionClusterKey()+"_"+pc.getCFID()+"_"+pc.getCFToken());
 		}
 		sct.setEL(TIMECREATED, timecreated);
 	}

--- a/railo-java/railo-loader/src/railo/runtime/listener/ApplicationContext.java
+++ b/railo-java/railo-loader/src/railo/runtime/listener/ApplicationContext.java
@@ -106,8 +106,10 @@ public interface ApplicationContext extends Serializable {
 	public TimeSpan getClientTimeout();
 	
 	public short getSessionType();
-	
+
 	public boolean getSessionCluster();
+	
+	public String getSessionClusterKey();
 
 	public boolean getClientCluster();
 
@@ -140,6 +142,7 @@ public interface ApplicationContext extends Serializable {
 	public void setSessionType(short sessionType);
 	public void setClientCluster(boolean clientCluster);
 	public void setSessionCluster(boolean sessionCluster);
+	public void setSessionClusterKey(String key);
 	public void setS3(Properties s3);
 	public void setORMEnabled(boolean ormenabled);
 	public void setORMConfiguration(ORMConfiguration ormConf);


### PR DESCRIPTION
My apologies. My previous pull request was based off some of my companies specific things we are doing.  This should be a more concise pull.

Problem: Different instances of a CFML application that are intended to be clustered (using sessionCluster=true) could only be clustered if the different instances have the same application name. two applications could be configured differently but still need to share session storage so they can't have the same application name.

Fix: Add this.sessionClusterKey (which defaults to the application name) that will be used for the sessionID and when getting the instance of the session "Cache". This allows for different instances of the same application with different application names to use the same session cache provided they each have this.sessionClusterKey="VALUE" to the same value.
