### PR TITLE
Cache Teardown

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/config/ConfigWebAdmin.java
+++ b/railo-java/railo-core/src/railo/runtime/config/ConfigWebAdmin.java
@@ -1662,6 +1662,7 @@ public final class ConfigWebAdmin {
         	parent.removeAttribute("default-query");
         if(name.equalsIgnoreCase(parent.getAttribute("default-resource")))
         	parent.removeAttribute("default-resource");
+      
         
         // remove element
         Element[] children = ConfigWebFactory.getChildren(parent,"connection");
@@ -1670,11 +1671,16 @@ public final class ConfigWebAdmin {
   	    	if(n!=null && n.equalsIgnoreCase(name)) {
   	    		Map conns = config.getCacheConnections();
   	    		CacheConnection cc=(CacheConnection) conns.get(n);
+  	    		
+  	    		//check if key is lower case
+  	    		if (cc == null) {
+  	    			cc = (CacheConnection) conns.get(n.toLowerCase());
+  	    		}
+  	    		
   	    		if(cc!=null)Util.removeEL(config instanceof ConfigWeb?(ConfigWeb)config:null,cc);
   	    	  parent.removeChild(children[i]);
   			}
   	    }
-      	
 	}
 	
 

--- a/railo-java/railo-core/src/railo/runtime/functions/cache/Util.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/cache/Util.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 
 import railo.commons.io.cache.Cache;
 import railo.commons.io.cache.CacheEntryFilter;
+import railo.commons.io.cache.CacheWithTeardown;
 import railo.commons.io.cache.exp.CacheException;
 import railo.commons.lang.StringUtil;
 import railo.runtime.PageContext;
@@ -147,12 +148,23 @@ public class Util {
 
 
 	public static boolean removeEL(ConfigWeb config, CacheConnection cc)  {
+		boolean success = false;
+		
 		try {
 			remove(config,cc);
-			return true;
+			success = true;
 		} catch (Throwable e) {
-			return false;
+			
 		}
+		
+		try {
+			teardownCacheConnection(config, cc);
+			success &= true;
+		} catch (Throwable e) {
+			e.printStackTrace();
+		}
+		
+		return success;
 	}
 	public static void remove(ConfigWeb config, CacheConnection cc) throws Throwable  {
 		Cache c = cc.getInstance(config);
@@ -174,6 +186,15 @@ public class Util {
 		}
 		catch (InvocationTargetException e) {
 			throw e.getTargetException();
+		}
+		
+	}
+	
+	private static void teardownCacheConnection(ConfigWeb config, CacheConnection connection) throws Throwable {
+		Cache cache = connection.getInstance(config);
+		
+		if (cache instanceof CacheWithTeardown) {
+			((CacheWithTeardown) cache).teardown();
 		}
 	}
 

--- a/railo-java/railo-loader/src/railo/commons/io/cache/CacheWithTeardown.java
+++ b/railo-java/railo-loader/src/railo/commons/io/cache/CacheWithTeardown.java
@@ -1,0 +1,5 @@
+package railo.commons.io.cache;
+
+public interface CacheWithTeardown {
+	public void teardown();
+}


### PR DESCRIPTION
Added cache interface named CacheWithTeardown.  A cache extension can optionally implement this interface.  The interface contains a single teardown method so the cache extension can know when Railo meant to delete it.  The teardown method can be used to clean up network connections and any other clean up tasks.
