### PR TITLE
set initial capacity to string builder instead of default 16

### DIFF
--- a/railo-java/railo-core/src/railo/commons/lang/StringUtil.java
+++ b/railo-java/railo-core/src/railo/commons/lang/StringUtil.java
@@ -455,7 +455,7 @@ public final class StringUtil {
         if(!onlyFirst && sub1.length()==1 && sub2.length()==1)return str.replace(sub1.charAt(0),sub2.charAt(0));
         
         
-        StringBuilder sb=new StringBuilder();
+        StringBuilder sb=new StringBuilder( sub2.length() > sub1.length() ? (int)Math.ceil( str.length() * 1.2 ) : str.length() );
         int start=0;
         int pos;
         int sub1Length=sub1.length();

--- a/railo-java/railo-core/src/railo/runtime/functions/string/ReplaceNoCase.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/string/ReplaceNoCase.java
@@ -23,7 +23,7 @@ public final class ReplaceNoCase implements Function {
 		
 		String lcStr=str.toLowerCase();
 		String lcSub1=sub1.toLowerCase();
-		StringBuffer sb=new StringBuffer();
+		StringBuilder sb=new StringBuilder( sub2.length() > sub1.length() ? (int)Math.ceil( str.length() * 1.2 ) : str.length() );
 		int start=0;
 		int pos;
 		int sub1Length=sub1.length();


### PR DESCRIPTION
also replaced StringBuffer with StringBuilder in ReplaceNoCase()

in my experience most strings that are used as input for Replace and ReplaceNoCase are longer than 16 chars.  using the default capacity will needlessly grow and copy the buffer multiple times.

if it doesn't make sense then simply reject this request.
