### PR TITLE
solves railo-2185

### DIFF
--- a/railo-cfml/railo-internal-cfml-functions/dump.cfm
+++ b/railo-cfml/railo-internal-cfml-functions/dump.cfm
@@ -20,7 +20,8 @@
     name="showUDFs" type="boolean" required="no" hint="show UDFs in cfdump output."><cfargument 
     name="top" type="numeric" required="no" hint="The number of rows to display."><cfargument 
     name="abort" type="boolean" required="no" hint="stops further processing of the request."><cfargument 
-    name="eval" type="string" required="no" hint="name of the variable to display, also used as label, when no label defined."><!---
+    name="eval" type="string" required="no" hint="name of the variable to display, also used as label, when no label defined."><cfargument 
+    name="async" type="boolean" required="no" hint="if true and output is not to browser, the dump-writing takes place in a separte thread."><!---
 
     ---><cfdump attributeCollection="#arguments#" contextlevel="3"><!---
 ---></cffunction>

--- a/railo-cfml/railo-internal-cfml-tags/Dump.cfc
+++ b/railo-cfml/railo-internal-cfml-tags/Dump.cfc
@@ -76,7 +76,7 @@ component {
 			else if(attrib.output EQ "browser") attrib['format'] = variables.default.browser;
 			else                                attrib['format'] = variables.default.console;
 		}
-		else if(not arrayFindNoCase(supportedFormats, attrib.format)){
+		else if( !arrayFindNoCase( variables.supportedFormats, attrib.format ) ) {
 			throw message="format [#attrib.format#] is not supported, supported formats are [#arrayToList(supportedFormats)#]";
 		}
 
@@ -89,11 +89,11 @@ component {
 		}
 		
 
-		if ( attributes.async && ( attributes.output NEQ "browser" ) ) {
+		if ( attrib.async && ( attrib.output NEQ "browser" ) ) {
 
-			thread name="dump-#createUUID()#" attrib="#attrib#" meta="#meta#" context="#context#" caller="#caller#" {
+			thread name="dump-#createUUID()#" attrib="#attrib#" meta="#meta#" context="#context#" caller="#arguments.caller#" {
 
-			//	try {
+			//	try {						// should we log errors? if so, enable the try/catch block
 
 					doOutput( attrib, meta, context, caller );
 
@@ -101,7 +101,7 @@ component {
 			}
 		} else {
 
-			doOutput( attrib, meta, context, caller );
+			doOutput( attrib, meta, context, arguments.caller );
 		}
 
 
@@ -116,22 +116,22 @@ component {
 
 		var dumpID = createId();
 
-		var hasReference = structKeyExists(meta,'hasReference') && meta.hasReference;
-		var result = this[attrib.format](meta, context, attrib.expand, attrib.output, hasReference, 0, dumpID);
+		var hasReference = structKeyExists( arguments.meta,'hasReference' ) && arguments.meta.hasReference;
+		var result = this[ arguments.attrib.format ]( arguments.meta, arguments.context, arguments.attrib.expand, arguments.attrib.output, hasReference, 0, dumpID );
 
 		// sleep( 5000 );	// simulate long process to test async=true
 		
-		if(attrib.output EQ "browser") {
+		if (arguments.attrib.output EQ "browser") {
 
 			echo(variables.NEWLINE & '<!-- ==start== dump #now()# format: #attrib.format# -->' & variables.NEWLINE);
 			echo('<div id="#dumpID#" class="-railo-dump">#result#</div>' & variables.NEWLINE);
 			echo('<!-- ==stop== dump -->' & variables.NEWLINE);
 		}
-		else if(attrib.output EQ "console") {
+		else if (arguments.attrib.output EQ "console") {
 			systemOutput(result);
 		}
 		else {
-			file action="write" addnewline="yes" file="#attrib.output#" output="#result#";
+			file action="write" addnewline="yes" file="#arguments.attrib.output#" output="#result#";
 		}
 	}
 

--- a/railo-cfml/railo-internal-cfml-tags/Dump.cfc
+++ b/railo-cfml/railo-internal-cfml-tags/Dump.cfc
@@ -93,11 +93,7 @@ component {
 
 			thread name="dump-#createUUID()#" attrib="#attrib#" meta="#meta#" context="#context#" caller="#arguments.caller#" {
 
-			//	try {						// should we log errors? if so, enable the try/catch block
-
-					doOutput( attrib, meta, context, caller );
-
-			//	} catch ( ex ) { file action="write" file="F:\test\railo-2185\err-#getTickCount()#.txt" output="#ex.toString()#"; }
+				doOutput( attrib, meta, context, caller );
 			}
 		} else {
 

--- a/railo-cfml/railo-internal-cfml-tags/Dump.cfc
+++ b/railo-cfml/railo-internal-cfml-tags/Dump.cfc
@@ -33,7 +33,8 @@ component {
 - html (default when output  equal ""browser""): regular output with html/css/javascript
 - classic: classic view with html/css/javascript"},
 		abort:{required:false,type:"boolean",default:false,hint="stops further processing of request."},
-		contextlevel:{required:false,type:"number",default:2,hidden:true}
+		contextlevel:{required:false,type:"number",default:2,hidden:true},
+		async:{required:false, type="boolean", default=false, hint="if true and output is not to browser, the dump-writing takes place in a separte thread."}
 	};
 
 
@@ -86,16 +87,44 @@ component {
 		catch(e) {
 			var meta = dumpStruct(structKeyExists(attrib,'var') ? attrib.var : nullValue(), attrib.top, attrib.show, attrib.hide, attrib.keys, attrib.metaInfo, attrib.showUDFs);
 		}
+		
+
+		if ( attributes.async && ( attributes.output NEQ "browser" ) ) {
+
+			thread name="dump-#createUUID()#" attrib="#attrib#" meta="#meta#" context="#context#" caller="#caller#" {
+
+			//	try {
+
+					doOutput( attrib, meta, context, caller );
+
+			//	} catch ( ex ) { file action="write" file="F:\test\railo-2185\err-#getTickCount()#.txt" output="#ex.toString()#"; }
+			}
+		} else {
+
+			doOutput( attrib, meta, context, caller );
+		}
+
+
+		if( attrib.abort )
+			abort;
+
+		return true;
+	}
+
+
+	function doOutput( attrib, meta, context, caller  ) {
+
 		var dumpID = createId();
 
-		// create output
 		var hasReference = structKeyExists(meta,'hasReference') && meta.hasReference;
 		var result = this[attrib.format](meta, context, attrib.expand, attrib.output, hasReference, 0, dumpID);
 
-		// output
+		// sleep( 5000 );	// simulate long process to test async=true
+		
 		if(attrib.output EQ "browser") {
+
 			echo(variables.NEWLINE & '<!-- ==start== dump #now()# format: #attrib.format# -->' & variables.NEWLINE);
-			echo('<div id="#dumpID#">#result#</div>' & variables.NEWLINE);
+			echo('<div id="#dumpID#" class="-railo-dump">#result#</div>' & variables.NEWLINE);
 			echo('<!-- ==stop== dump -->' & variables.NEWLINE);
 		}
 		else if(attrib.output EQ "console") {
@@ -104,12 +133,8 @@ component {
 		else {
 			file action="write" addnewline="yes" file="#attrib.output#" output="#result#";
 		}
-
-		// abort
-		if(attrib.abort) abort;
-
-		return true;
 	}
+
 
 	/* ==================================================================================================
 	   html                                                                                             =
@@ -139,7 +164,7 @@ component {
 				var comment = structKeyExists(arguments.meta,'comment') ? "<br />" & replace(HTMLEditFormat(arguments.meta.comment),chr(10),' <br>','all') : '';
 
 				rtn&=('<tr>');
-				rtn&=('<td class="#doCSSColors(arguments.cssColors,arguments.meta.highLightColor)#" onclick="dumpOC(''#id#'');" colspan="#columnCount#">');
+				rtn&=('<td class="#doCSSColors(arguments.cssColors,arguments.meta.highLightColor)#" onclick="dumpOC(''#id#'');" colspan="#columnCount#" style="cursor:pointer;">');
 				rtn&=('<span>#arguments.meta.title##metaID#</span>');
 				rtn&=(comment & '</td>');
 				rtn&=('</tr>');
@@ -276,7 +301,7 @@ component {
 				var comment = structKeyExists(arguments.meta,'comment') ? "<br />" & replace(HTMLEditFormat(arguments.meta.comment),chr(10),' <br>','all') : '';
 
 				rtn&=('<tr>');
-				rtn&=('<td onclick="dumpOC(''#id#'');" colspan="#columnCount#" style="background:#h1Color#; border-color:#borderColor#; color:white;">');
+				rtn&=('<td onclick="dumpOC(''#id#'');" colspan="#columnCount#" style="background:#h1Color#; border-color:#borderColor#; color:white;" style="cursor:pointer;">');
 				rtn&=('<span>#arguments.meta.title##metaID#</span>');
 				rtn&=(comment & '</td>');
 				rtn&=('</tr>');


### PR DESCRIPTION
added async attribute to cfdump

the generation of the html and writing to file now happen in a separate thread if async is true and output is not set to browser.

I tried to do the calls to dumpStruct() in a separate thread but when I added sleep() to simulate a long process I got NPE in the separate thread, probably because the request ended and the page-context was not valid anymore.  
