### PR TITLE
IE8 railo admin compatibility

### DIFF
--- a/railo-cfml/railo-admin/admin/admin_layout.cfm
+++ b/railo-cfml/railo-admin/admin/admin_layout.cfm
@@ -25,6 +25,7 @@
 	<script src="resources/js/jquery-1.7.2.min.js.cfm" type="text/javascript"></script>
 	<script src="resources/js/jquery.blockUI.js.cfm" type="text/javascript"></script>
 	<script src="resources/js/admin.js.cfm" type="text/javascript"></script>
+	<!--[if IE lt 9]><script>$(function(){$('body').addClass('ielt9')})</script><![endif]-->
 </head>
 <cfoutput>
 <body id="body" class="#request.adminType#<cfif application.adminfunctions.getdata('fullscreen') eq 1> full</cfif>" <cfif structKeyExists(attributes,"onload")>onload="#attributes.onload#"</cfif>>

--- a/railo-cfml/railo-admin/admin/resources/css/style.css.cfm
+++ b/railo-cfml/railo-admin/admin/resources/css/style.css.cfm
@@ -522,13 +522,17 @@ a.edit {
 	background-image: url(../img/edit.png.cfm), -webkit-linear-gradient(top, #fff,#ddd); /* Chrome 10+, Saf5.1+ */
 	background-image: url(../img/edit.png.cfm),	-moz-linear-gradient(top, #fff,#ddd); /* FF3.6+ */
 	background-image: url(../img/edit.png.cfm),	 -ms-linear-gradient(top, #fff,#ddd); /* IE10 */
-	background-image: url(../img/edit.png.cfm),	  -o-linear-gradient(top, #fff,#ddd); /* Opera 11.10+ */
-	background-image: url(../img/edit.png.cfm),         linear-gradient(top, #fff,#ddd); /* W3C */
+	background-image: url(../img/edit.png.cfm),	 -o-linear-gradient(top, #fff,#ddd); /* Opera 11.10+ */
+	background-image: url(../img/edit.png.cfm),  linear-gradient(top, #fff,#ddd); /* W3C */
 	background-repeat: no-repeat;
 	background-position: center;
 	line-height:18px;
 	width:20px;
 }
+.ielt9 a.edit {/*ie 8*/
+	background-image: url(../img/edit.png.cfm);
+}
+
 .btn-search {
 	background-image: url(../img/search_icon.png.cfm); /* fallback */
 	background-image: url(../img/search_icon.png.cfm), -webkit-linear-gradient(top, #fff,#ddd); /* Chrome 10+, Saf5.1+ */
@@ -542,6 +546,10 @@ a.edit {
 	height:20px;
 	width:20px;
 }
+.ielt9 .btn-search {/*ie 8*/
+	background-image: url(../img/search_icon.png.cfm);
+}
+
 .btn-mini span {
 	display:none;
 }

--- a/railo-cfml/railo-admin/admin/resources/js/admin.js.cfm
+++ b/railo-cfml/railo-admin/admin/resources/js/admin.js.cfm
@@ -174,7 +174,7 @@ function checkTheBox(field) {
 	if (box.filter(':checked').length==0)
 	{
 		// calls the click handlers as well
-		$(box).click();
+		box.prop('checked', 'checked').triggerHandler('change');
 	}
 }
 


### PR DESCRIPTION
In the admin on IE8, button images weren't showing, and buttons underneath a "checkbox table" were not activated when a checkbox was checked by using javascript (eg. the custom tag resources form)

https://issues.jboss.org/browse/RAILO-2247
