### PR TITLE
Fixed Endless Loop with two escaped single quotes \'\' inside a string.

### DIFF
--- a/railo-java/railo-core/src/resource/component/org/railo/cfml/Base.cfc
+++ b/railo-java/railo-core/src/resource/component/org/railo/cfml/Base.cfc
@@ -137,16 +137,16 @@
 				<!--- declare the query local var --->
 				<cfset var q = "">
 				
-				<cfquery name="q" attributeCollection="#tagAttributes#" result="tagResult">
-					<cfloop array="#qArray#" index="item">
+				<cfquery name="q" attributeCollection="#tagAttributes#" result="tagResult"><!---
+					---><cfloop array="#qArray#" index="item"><!---
 						<!--- item is s string so just output --->
-						<cfif structKeyExists(item,'type') and item.type eq 'string'>
-							#preserveSingleQuotes(item.value)#
-						<cfelse>
-							<cfqueryparam attributecollection="#item#">
-						</cfif>
-					</cfloop>
-				</cfquery>
+						---><cfif structKeyExists(item,'type') and item.type eq 'string'><!---
+							--->#preserveSingleQuotes(item.value)#<!---
+						---><cfelse><!---
+							---><cfqueryparam attributecollection="#item#"><!---
+						---></cfif><!---
+					---></cfloop><!---
+				---></cfquery>
 				
 				<cfset result.setResult(q)>			
 				<cfset result.setPrefix(tagResult)>

--- a/railo-java/railo-core/src/resource/component/org/railo/cfml/Query.cfc
+++ b/railo-java/railo-core/src/resource/component/org/railo/cfml/Query.cfc
@@ -65,7 +65,7 @@ component output="false" extends="Base" accessors="true"{
 					Len++ ;
 
 					// If escaped quote, skip twice.
-					if (Mid(Sql,Pos+Len,2) EQ "\" & NextChar) Len+=2;
+					if (Mid(Sql,Pos+Len,2) EQ "\" & NextChar) Len+=1;
 				}
 				// Include closing quote:
 				Len++ ;


### PR DESCRIPTION
This pull should fix this issue:
https://issues.jboss.org/browse/RAILO-2251

Thanks!
