### PR TITLE
Dump.cfc has an error with compiled code.

### DIFF
--- a/railo-java/railo-core/src/resource/library/tag/Dump.cfc
+++ b/railo-java/railo-core/src/resource/library/tag/Dump.cfc
@@ -65,6 +65,7 @@ component {
 		// context
 		var context = GetCurrentContext();
 		var contextLevel = structKeyExists(attrib,'contextLevel') ? attrib.contextLevel : 2;
+		contextLevel = min(contextLevel,arrayLen(context));
 		context = context[contextLevel].template & ":" & context[contextLevel].line;
 
 		// format


### PR DESCRIPTION
basicly the variable 'contextLevel' is used as an index to the context array and the contextLevel is larger than the array (2).  This only happens when you do a dump with compiled code, and even then it doesn't happen all the time. I am not sure the conditions that must be met, but I figure the one line change that is part of this pull is safe.  I wish I knew what actually causes it...

Here is the error: (We change the library/tags location to the location specified in the error if you have a question about it)

Element at position [2] doesn't exist in array
    at railo.runtime.type.ArrayImpl.invalidPosition(Unknown Source):-1
    at railo.runtime.type.ArrayImpl.getE(Unknown Source):-1
    at railo.runtime.type.ArrayImpl.get(Unknown Source):-1
    at railo.runtime.type.util.ArraySupport.get(Unknown Source):-1
    at railo.runtime.util.VariableUtilImpl.get(Unknown Source):-1
    at railo.runtime.util.VariableUtilImpl.getCollection(Unknown Source):-1
    at railo.runtime.PageContextImpl.getCollection(Unknown Source):-1
    at dump_cfc$cf.udfCall(C:\MasterControl\server\mastercontrol\MCML\tags\Dump.cfc:68):68
    at railo.runtime.type.UDFImpl.implementation(Unknown Source):-1
    at railo.runtime.type.UDFImpl._call(Unknown Source):-1
    at railo.runtime.type.UDFImpl.callWithNamedValues(Unknown Source):-1
    at railo.runtime.ComponentImpl._call(Unknown Source):-1
    at railo.runtime.ComponentImpl._call(Unknown Source):-1
    at railo.runtime.ComponentImpl.callWithNamedValues(Unknown Source):-1
    at railo.runtime.tag.CFTag.cfcStartTag(Unknown Source):-1
    at railo.runtime.tag.CFTag.doStartTag(Unknown Source):-1
    at deployment.application_cfc$cf.udfCall(Unknown Source):-1
    at railo.runtime.type.UDFImpl.implementation(Unknown Source):-1
    at railo.runtime.type.UDFImpl._call(Unknown Source):-1
    at railo.runtime.type.UDFImpl.call(Unknown Source):-1
    at railo.runtime.ComponentImpl._call(Unknown Source):-1
    at railo.runtime.ComponentImpl._call(Unknown Source):-1
    at railo.runtime.ComponentImpl.call(Unknown Source):-1
    at railo.runtime.listener.ModernAppListener.call(Unknown Source):-1
    at railo.runtime.listener.ModernAppListener.onError(Unknown Source):-1
    at railo.runtime.PageContextImpl.execute(Unknown Source):-1
    at railo.runtime.PageContextImpl.execute(Unknown Source):-1
    at railo.runtime.engine.CFMLEngineImpl.serviceCFML(Unknown Source):-1
    at railo.loader.servlet.CFMLServlet.service(Unknown Source):-1
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:722):722
    at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:305):305
    at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210):210
    at org.tuckey.web.filters.urlrewrite.RuleChain.handleRewrite(RuleChain.java:176):176
    at org.tuckey.web.filters.urlrewrite.RuleChain.doRules(RuleChain.java:145):145
    at org.tuckey.web.filters.urlrewrite.UrlRewriter.processRequest(UrlRewriter.java:92):92
    at org.tuckey.web.filters.urlrewrite.UrlRewriteFilter.doFilter(UrlRewriteFilter.java:381):381
    at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:243):243
    at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210):210
    at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:222):222
    at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:123):123
    at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:472):472
    at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:168):168
    at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:99):99
    at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:118):118
    at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:407):407
    at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1002):1002
    at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:585):585
    at org.apache.tomcat.util.net.AprEndpoint$SocketProcessor.run(AprEndpoint.java:1813):1813
    at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source):-1
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source):-1
    at java.lang.Thread.run(Unknown Source):-1
