### PR TITLE
Fixes for the word "maximal" in the codebase.

### DIFF
--- a/railo-cfml/railo-admin/admin/cdriver/EHCache.cfc
+++ b/railo-cfml/railo-admin/admin/cdriver/EHCache.cfc
@@ -4,7 +4,7 @@
 	
     <cfset fields=array(
 		field("Eternal","eternal","false",true,"Sets whether elements are eternal. If eternal, timeouts are ignored and the element is never expired","checkbox","true"),
-		field("Maximal elements in memory","maxelementsinmemory","10000",true,"Sets the maximum objects to be held in memory","text"),
+		field("Maximum elements in memory","maxelementsinmemory","10000",true,"Sets the maximum number of objects to be held in memory","text"),
 		field("Memory Store Eviction Policy","memoryevictionpolicy","LRU,LFU,FIFO",true,"The algorithm to used to evict old entries when maximum limit is reached, such as LRU (least recently used), LFU (least frequently used) or FIFO (first in first out).","select"),
 		field("Time to idle in seconds","timeToIdleSeconds","86400",true,"Sets the time to idle for an element before it expires. Is only used if the element is not eternal","time"),
 		field("Time to live in seconds","timeToLiveSeconds","86400",true,"Sets the timeout to live for an element before it expires. Is only used if the element is not eternal","time"),
@@ -12,7 +12,7 @@
 		//group("Disk","Hard disk specific settings"),
 		field("Disk persistent","diskpersistent","true",true,"for caches that overflow to disk, whether the disk store persists between restarts of the Engine.","checkbox","true"),
 		field("Overflow to disk","overflowtodisk","true",true,"for caches that overflow to disk, the disk cache persist between CacheManager instances","checkbox","true"),
-		field("Maximal elements on disk","maxelementsondisk","10000000",true,"Sets the maximum number elements on Disk. 0 means unlimited","text"),
+		field("Maximum elements on disk","maxelementsondisk","10000000",true,"Sets the maximum number of elements on Disk. 0 means unlimited","text"),
 		
 		
 		group("Distributed","Ehcache comes with a built-in RMI-based distribution system"),

--- a/railo-cfml/railo-admin/admin/cdriver/EHCacheLite.cfc
+++ b/railo-cfml/railo-admin/admin/cdriver/EHCacheLite.cfc
@@ -4,7 +4,7 @@
 	
     <cfset fields=array(
 		field("Eternal","eternal","false",true,"Sets whether elements are eternal. If eternal, timeouts are ignored and the element is never expired","checkbox","true"),
-		field("Maximal elements in memory","maxelementsinmemory","10000",true,"Sets the maximum objects to be held in memory","text"),
+		field("Maximum elements in memory","maxelementsinmemory","10000",true,"Sets the maximum number of objects to be held in memory","text"),
 		field("Memory Store Eviction Policy","memoryevictionpolicy","LRU,LFU,FIFO",true,"The algorithm to used to evict old entries when maximum limit is reached, such as LRU (least recently used), LFU (least frequently used) or FIFO (first in first out).","select"),
 		field("Time to idle in seconds","timeToIdleSeconds","86400",true,"Sets the time to idle for an element before it expires. Is only used if the element is not eternal","time"),
 		field("Time to live in seconds","timeToLiveSeconds","86400",true,"Sets the timeout to live for an element before it expires. Is only used if the element is not eternal","time"),
@@ -12,7 +12,7 @@
 		//group("Disk","Hard disk specific settings"),
 		field("Disk persistent","diskpersistent","true",true,"for caches that overflow to disk, whether the disk store persists between restarts of the Engine.","checkbox","true"),
 		field("Overflow to disk","overflowtodisk","true",true,"for caches that overflow to disk, the disk cache persist between CacheManager instances","checkbox","true"),
-		field("Maximal elements on disk","maxelementsondisk","10000000",true,"Sets the maximum number elements on Disk. 0 means unlimited","text")
+		field("Maximum elements on disk","maxelementsondisk","10000000",true,"Sets the maximum number of elements on Disk. 0 means unlimited","text")
 		
 		
 		

--- a/railo-cfml/railo-admin/admin/cdriver/MemCache.cfc
+++ b/railo-cfml/railo-admin/admin/cdriver/MemCache.cfc
@@ -5,10 +5,10 @@
 		
 		,field("Initial connections","initial_connections","1",false,"how many initial connetions are set (initial setting ""1"")","text")
 		,field("Minimal spare connections","min_spare_connections","1",false,"minimal amount of connections (initial setting ""1"")","text")
-		,field("Maximal spare connections","max_spare_connections","32",false,"maximal amount of connections (initial setting ""32"")","text")
+		,field("Maximum spare connections","max_spare_connections","32",false,"maximum amount of connections (initial setting ""32"")","text")
 		
-		,field("Maximal idle time","max_idle_time","600",false,"maximal idle time for available sockets (initial setting ""10 minutes"")","time")
-		,field("Maximal busy time","max_busy_time","30",false,"maximal busy time for available sockets (initial setting ""30 seconds"")","time")
+		,field("Maximum idle time","max_idle_time","600",false,"maximum idle time for available sockets (initial setting ""10 minutes"")","time")
+		,field("Maximum busy time","max_busy_time","30",false,"maximum busy time for available sockets (initial setting ""30 seconds"")","time")
 		,field("thread maintenance","maint_thread_sleep","5",false,"maintenance thread sleep time (initial setting ""5 seconds"")","time")
 		,field("Socket timeout","socket_timeout","30",false,"default timeout of socket reads (initial setting ""30 seconds"")","time")
 		,field("Socket connection timeout","socket_connect_to","3",false,"timeout for socket connections (initial setting ""3 seconds"")","time")

--- a/railo-cfml/railo-admin/admin/debugging.logs.cfm
+++ b/railo-cfml/railo-admin/admin/debugging.logs.cfm
@@ -13,7 +13,7 @@
 <cfset stText.debug.exeTimeQuery="Query">
 <cfset stText.debug.exeTimeTotal="Total">
 <cfset stText.debug.exeTimeApp="App">
-<cfset stText.debug.maxLogs="Maximal Logged Requests">
+<cfset stText.debug.maxLogs="Maximum Logged Requests">
 <cfset stText.debug.minExeTime="Minimal Execution Time (ms)">
 <cfset stText.debug.minExeTimeDesc="Minimal Execution Time that Railo outputs the debugger information of a request.">
 <cfset stText.debug.pathRestriction="Path Restriction">

--- a/railo-cfml/railo-admin/admin/language.xml
+++ b/railo-cfml/railo-admin/admin/language.xml
@@ -1417,7 +1417,7 @@
 		<custom key="settings.dbclobdesc">Enable long text retrieval (&lt;abbr title=&quot;character large object&quot;&gt;CLOB&lt;/abbr&gt;)</custom>
 		<custom key="settings.dbconnlimit">Connection limit (max)</custom>
 	
-		<custom key="settings.dbconnlimitdesc">Restricts the maximal connections at time</custom>
+		<custom key="settings.dbconnlimitdesc">Restricts the maximum number of connections at one time</custom>
 		<custom key="settings.dbconnlimitinf">- inf -</custom>
 		<custom key="settings.dbconntimeout">Connection timeout (in minutes)</custom>
 		<custom key="settings.dbconntimeoutdesc">Define a time in minutes for how long a connection is kept alive before it will be closed</custom>

--- a/railo-cfml/railo-admin/admin/resources/language/en.xml
+++ b/railo-cfml/railo-admin/admin/resources/language/en.xml
@@ -872,7 +872,7 @@ sct[""bracketNotation""] --> keyname: "bracketNotation"</data>
 	<data key="settings.dbconnlimit">Connection limit (max)</data>
 	<data key="settings.dbconntimeoutdesc">Define a time in minutes for how long a connection is kept alive before it will be closed</data>
 	<data key="settings.dbportdesc">The port to connect the database</data>
-	<data key="settings.dbconnlimitdesc">Restricts the maximal connections at time</data>
+	<data key="settings.dbconnlimitdesc">Restricts the maximum number of simultaneous connections at one time</data>
 	<data key="settings.listdatasourcesdescserver">Datasources created here are available for ALL web contexts to use. The settings for these datasources can only be modified in this Server Administrator area.</data>
 	<data key="settings.dballowed">Allowed operations</data>
 	<data key="Settings.dbStorage">Storage</data>

--- a/railo-java/railo-core/src/railo/commons/io/log/LogResource.java
+++ b/railo-java/railo-core/src/railo/commons/io/log/LogResource.java
@@ -15,7 +15,7 @@ public class LogResource implements Log {
 
 
 	/**
-     * maximal count of files (history of files) 
+     * maximum number of files (history of files) 
      */
     public static final int MAX_FILES=10;
 
@@ -168,7 +168,7 @@ public class LogResource implements Log {
     }
     
     /**
-     * maximal file size of for a log file
+     * maximum file size of for a log file
      */
     public static final long MAX_FILE_SIZE=1024*1024;
     /**

--- a/railo-java/railo-core/src/railo/runtime/PageContextImpl.java
+++ b/railo-java/railo-core/src/railo/runtime/PageContextImpl.java
@@ -1387,7 +1387,7 @@ public final class PageContextImpl extends PageContext implements Sizeable {
 				if(!Decision.isCastableTo(type,value,true,true,maxLength)) {
 					if(maxLength>-1 && ("email".equalsIgnoreCase(type) || "url".equalsIgnoreCase(type) || "string".equalsIgnoreCase(type))) {
 						StringBuilder msg=new StringBuilder(CasterException.createMessage(value, type));
-						msg.append(" with a maximal length of "+maxLength+" characters");
+						msg.append(" with a maximum length of "+maxLength+" characters");
 						throw new CasterException(msg.toString());	
 					}
 					throw new CasterException(value,type);	

--- a/railo-java/railo-core/src/railo/runtime/dump/DumpUtil.java
+++ b/railo-java/railo-core/src/railo/runtime/dump/DumpUtil.java
@@ -45,7 +45,7 @@ public class DumpUtil {
 	
 	public static DumpData toDumpData(Object o,PageContext pageContext, int maxlevel, DumpProperties props) {
 		if(maxlevel<=0) {
-			return new SimpleDumpData("maximal dump level reached");
+			return new SimpleDumpData("maximum dump level reached");
 		}
 		// null
 		if(o == null) {

--- a/railo-java/railo-core/src/railo/runtime/ext/tag/TagMetaDataImpl.java
+++ b/railo-java/railo-core/src/railo/runtime/ext/tag/TagMetaDataImpl.java
@@ -22,7 +22,7 @@ public class TagMetaDataImpl implements TagMetaData {
 	 * Constructor of the class
 	 * @param attrType TagMetaData.ATTRIBUTE_TYPE_FIX,TagMetaData.ATTRIBUTE_TYPE_DYNAMIC,TagMetaData.ATTRIBUTE_TYPE_MIXED
 	 * @param attrMin minimal count of attributes needed for tag
-	 * @param attrMax maximal count of attributes or -1 for infinity attributes
+	 * @param attrMax maximum count of attributes or -1 for infinity attributes
 	 * @param bodyContent TagMetaData.BODY_CONTENT_EMPTY,TagMetaData.BODY_CONTENT_FREE,TagMetaData.BODY_CONTENT_MUST
 	 * @param isBodyRE is the body of the tag parsed like inside a cfoutput
 	 * @param description A description of the tag.

--- a/railo-java/railo-core/src/railo/runtime/functions/math/InputBaseN.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/math/InputBaseN.java
@@ -17,7 +17,7 @@ public final class InputBaseN implements Function {
 		if(string.startsWith("0x")) string=string.substring(2, string.length());
 		
 		if(string.length()>32)
-			throw new FunctionException(pc,"inputBaseN",1,"string","argument is to large can be maximal 32 digits (-0x at start)");
+			throw new FunctionException(pc,"inputBaseN",1,"string","argument is to large can be a maximum of 32 digits (-0x at start)");
 		
         //print.ln(string+"-"+radix);
 		return (int)Long.parseLong(string, (int)radix);

--- a/railo-java/railo-core/src/railo/runtime/tag/Http3.java
+++ b/railo-java/railo-core/src/railo/runtime/tag/Http3.java
@@ -87,7 +87,7 @@ public final class Http3 extends BodyTagImpl implements Http {
 	
 
     /**
-     * Maximal count of redirects (5)
+     * maximum redirect count (5)
      */
     public static final short MAX_REDIRECT=15;
     

--- a/railo-java/railo-core/src/railo/runtime/tag/Http4.java
+++ b/railo-java/railo-core/src/railo/runtime/tag/Http4.java
@@ -95,7 +95,7 @@ public final class Http4 extends BodyTagImpl implements Http {
 	public static final String MULTIPART_FORM_DATA = "multipart/form-data";
 
     /**
-     * Maximal count of redirects (5)
+     * Maximum redirect count (5)
      */
     public static final short MAX_REDIRECT=15;
     

--- a/railo-java/railo-core/src/railo/runtime/text/xml/XMLCaster.java
+++ b/railo-java/railo-core/src/railo/runtime/text/xml/XMLCaster.java
@@ -597,7 +597,7 @@ public final class XMLCaster {
 	 */
 	public static DumpData toDumpData(Node node, PageContext pageContext, int maxlevel, DumpProperties props) {
 		if(maxlevel<=0) {
-			return new SimpleDumpData("maximal dump level reached");
+			return new SimpleDumpData("maxumum dump level reached");
 		}
 		maxlevel--;
 		// Document

--- a/railo-java/railo-core/src/railo/runtime/type/UDFGSProperty.java
+++ b/railo-java/railo-core/src/railo/runtime/type/UDFGSProperty.java
@@ -212,7 +212,7 @@ public abstract class UDFGSProperty extends UDFImpl {
 			if(!Double.isNaN(min) && l<((int)min))
 				throw new ExpressionException("string ["+str+"] is to short ["+l+"], the string must be at least ["+min+"] characters");
 			if(!Double.isNaN(max) && l>((int)max))
-				throw new ExpressionException("string ["+str+"] is to long ["+l+"], the string can have a maximal length of ["+max+"] characters");
+				throw new ExpressionException("string ["+str+"] is to long ["+l+"], the string can have a maximum length of ["+max+"] characters");
 		}
 		else if(validate.equals("regex")){
 			String pattern=Caster.toString(validateParams.get(KeyConstants._pattern,null),null);

--- a/railo-java/railo-core/src/railo/transformer/cfml/tag/CFMLTransformer.java
+++ b/railo-java/railo-core/src/railo/transformer/cfml/tag/CFMLTransformer.java
@@ -868,11 +868,11 @@ public final class CFMLTransformer {
 			
 			// to less attributes
 			if(!hasAttributeCollection && min>count)
-				throw createTemplateException(data.cfml,"the tag "+tag.getFullName()+" must have "+min+" attributes at least",tag);
+				throw createTemplateException(data.cfml,"the tag "+tag.getFullName()+" must have at least "+min+" attributes",tag);
 			
 			// too much attributes
 			if(!hasAttributeCollection && max>0 && max<count)
-				throw createTemplateException(data.cfml,"the tag "+tag.getFullName()+" can have "+max+" attributes maximal",tag);
+				throw createTemplateException(data.cfml,"the tag "+tag.getFullName()+" can have a maximum of "+max+" attributes",tag);
 			
 			// not defined attributes
 			if(type==TagLibTag.ATTRIBUTE_TYPE_FIXED || type==TagLibTag.ATTRIBUTE_TYPE_MIXED)	{

--- a/railo-java/railo-core/src/resource/config/server.xml
+++ b/railo-java/railo-core/src/resource/config/server.xml
@@ -176,7 +176,7 @@ Path placeholders:
 			when yes all form and url scope are synonym for both data
 		
 		client-directory-max-size
-			maximal size in bytes of the client scope directory (used for default type file)
+			maximum size in bytes of the client scope directory (used for default type file)
 		
 		client-max-age
 			the max age of the client scope in days

--- a/railo-java/railo-core/src/resource/context/admin/cdriver/EHCache.cfc
+++ b/railo-java/railo-core/src/resource/context/admin/cdriver/EHCache.cfc
@@ -4,7 +4,7 @@
 	
     <cfset fields=array(
 		field("Eternal","eternal","false",true,"Sets whether elements are eternal. If eternal, timeouts are ignored and the element is never expired","checkbox","true"),
-		field("Maximal elements in memory","maxelementsinmemory","10000",true,"Sets the maximum objects to be held in memory","text"),
+		field("Maximum elements in memory","maxelementsinmemory","10000",true,"Sets the maximum objects to be held in memory","text"),
 		field("Memory Store Eviction Policy","memoryevictionpolicy","LRU,LFU,FIFO",true,"The algorithm to used to evict old entries when maximum limit is reached, such as LRU (least recently used), LFU (least frequently used) or FIFO (first in first out).","select"),
 		field("Time to idle in seconds","timeToIdleSeconds","86400",true,"Sets the time to idle for an element before it expires. Is only used if the element is not eternal","time"),
 		field("Time to live in seconds","timeToLiveSeconds","86400",true,"Sets the timeout to live for an element before it expires. Is only used if the element is not eternal","time"),
@@ -12,7 +12,7 @@
 		//group("Disk","Hard disk specific settings"),
 		field("Disk persistent","diskpersistent","true",true,"for caches that overflow to disk, whether the disk store persists between restarts of the Engine.","checkbox","true"),
 		field("Overflow to disk","overflowtodisk","true",true,"for caches that overflow to disk, the disk cache persist between CacheManager instances","checkbox","true"),
-		field("Maximal elements on disk","maxelementsondisk","10000000",true,"Sets the maximum number elements on Disk. 0 means unlimited","text"),
+		field("Maximum elements on disk","maxelementsondisk","10000000",true,"Sets the maximum number of elements on disk. 0 means unlimited","text"),
 		
 		
 		group("Distributed","Ehcache comes with a built-in RMI-based distribution system"),

--- a/railo-java/railo-core/src/resource/context/admin/cdriver/EHCacheLite.cfc
+++ b/railo-java/railo-core/src/resource/context/admin/cdriver/EHCacheLite.cfc
@@ -4,7 +4,7 @@
 	
     <cfset fields=array(
 		field("Eternal","eternal","false",true,"Sets whether elements are eternal. If eternal, timeouts are ignored and the element is never expired","checkbox","true"),
-		field("Maximal elements in memory","maxelementsinmemory","10000",true,"Sets the maximum objects to be held in memory","text"),
+		field("Maximum elements in memory","maxelementsinmemory","10000",true,"Sets the maximum number of objects to be held in memory","text"),
 		field("Memory Store Eviction Policy","memoryevictionpolicy","LRU,LFU,FIFO",true,"The algorithm to used to evict old entries when maximum limit is reached, such as LRU (least recently used), LFU (least frequently used) or FIFO (first in first out).","select"),
 		field("Time to idle in seconds","timeToIdleSeconds","86400",true,"Sets the time to idle for an element before it expires. Is only used if the element is not eternal","time"),
 		field("Time to live in seconds","timeToLiveSeconds","86400",true,"Sets the timeout to live for an element before it expires. Is only used if the element is not eternal","time"),
@@ -12,7 +12,7 @@
 		//group("Disk","Hard disk specific settings"),
 		field("Disk persistent","diskpersistent","true",true,"for caches that overflow to disk, whether the disk store persists between restarts of the Engine.","checkbox","true"),
 		field("Overflow to disk","overflowtodisk","true",true,"for caches that overflow to disk, the disk cache persist between CacheManager instances","checkbox","true"),
-		field("Maximal elements on disk","maxelementsondisk","10000000",true,"Sets the maximum number elements on Disk. 0 means unlimited","text")
+		field("Maximum elements on disk","maxelementsondisk","10000000",true,"Sets the maximum number elements on disk. 0 means unlimited","text")
 		
 		
 		

--- a/railo-java/railo-core/src/resource/context/admin/cdriver/MemCache.cfc
+++ b/railo-java/railo-core/src/resource/context/admin/cdriver/MemCache.cfc
@@ -5,10 +5,10 @@
 		
 		,field("Initial connections","initial_connections","1",false,"how many initial connetions are set (initial setting ""1"")","text")
 		,field("Minimal spare connections","min_spare_connections","1",false,"minimal amount of connections (initial setting ""1"")","text")
-		,field("Maximal spare connections","max_spare_connections","32",false,"maximal amount of connections (initial setting ""32"")","text")
+		,field("Maximum spare connections","max_spare_connections","32",false,"maximum amount of connections (initial setting ""32"")","text")
 		
-		,field("Maximal idle time","max_idle_time","600",false,"maximal idle time for available sockets (initial setting ""10 minutes"")","time")
-		,field("Maximal busy time","max_busy_time","30",false,"maximal busy time for available sockets (initial setting ""30 seconds"")","time")
+		,field("Maximum idle time","max_idle_time","600",false,"maximum idle time for available sockets (initial setting ""10 minutes"")","time")
+		,field("Maximum busy time","max_busy_time","30",false,"maximum busy time for available sockets (initial setting ""30 seconds"")","time")
 		,field("thread maintenance","maint_thread_sleep","5",false,"maintenance thread sleep time (initial setting ""5 seconds"")","time")
 		,field("Socket timeout","socket_timeout","30",false,"default timeout of socket reads (initial setting ""30 seconds"")","time")
 		,field("Socket connection timeout","socket_connect_to","3",false,"timeout for socket connections (initial setting ""3 seconds"")","time")

--- a/railo-java/railo-core/src/resource/context/admin/resources/language/en.xml
+++ b/railo-java/railo-core/src/resource/context/admin/resources/language/en.xml
@@ -849,7 +849,7 @@ sct[""bracketNotation""] --> keyname: "bracketNotation"</data>
 	<data key="settings.dbconnlimit">Connection limit (max)</data>
 	<data key="settings.dbconntimeoutdesc">Define a time in minutes for how long a connection is kept alive before it will be closed</data>
 	<data key="settings.dbportdesc">The port to connect the database</data>
-	<data key="settings.dbconnlimitdesc">Restricts the maximal connections at time</data>
+	<data key="settings.dbconnlimitdesc">Restricts the number of maximum connections at one time</data>
 	<data key="settings.listdatasourcesdescserver">Datasources created here are available for ALL web contexts to use. The settings for these datasources can only be modified in this Server Administrator area.</data>
 	<data key="settings.dballowed">Allowed operations</data>
 	<data key="Settings.dbStorage">Storage</data>

--- a/railo-java/railo-core/src/resource/dtd/web-cfmtaglibrary_1_0.dtd
+++ b/railo-java/railo-core/src/resource/dtd/web-cfmtaglibrary_1_0.dtd
@@ -140,7 +140,7 @@ Minimal length of attributes
  -->
 <!ELEMENT attribute-min (#PCDATA)>
 <!-- 
-Maximal length of attributes
+Maximum length of attributes
  -->
 <!ELEMENT attribute-max (#PCDATA)>
 <!--

--- a/railo-java/railo-core/src/resource/fld/web-cfmfunctionlibrary_1_0
+++ b/railo-java/railo-core/src/resource/fld/web-cfmfunctionlibrary_1_0
@@ -375,7 +375,7 @@ All elements in the array must contain values that can be automatically converte
 			<type>number</type>
 			<required>No</required>
 			<default>20</default>
-			<description>maximal numbers of threads executed, ignored when argument "parallel" is set to false</description>
+			<description>maximum number of threads executed, ignored when argument "parallel" is set to false</description>
 		</argument>
 		<return>
 			<type>void</type>
@@ -804,7 +804,7 @@ Remember CFML arrays start at 1 not 0.</description>
 			<name>length</name>
 			<type>number</type>
 			<required>No</required>
-		<description>maximal elements to slice from offset</description>
+		<description>maximum elements to slice from offset</description>
     </argument>
 		<return>
 			<type>array</type>
@@ -14763,7 +14763,7 @@ You can find a list of all available timezones in the Railo administrator (Setti
 			<type>number</type>
 			<required>No</required>
 			<default>20</default>
-			<description>maximal numbers of threads executed, ignored when argument "parallel" is set to false</description>
+			<description>maximum number of threads executed, ignored when argument "parallel" is set to false</description>
 		</argument>
 		<return>
 			<type>void</type>
@@ -14800,7 +14800,7 @@ You can find a list of all available timezones in the Railo administrator (Setti
 			<type>number</type>
 			<required>No</required>
 			<default>20</default>
-			<description>maximal numbers of threads executed, ignored when argument "parallel" is set to false</description>
+			<description>maximum number of threads executed, ignored when argument "parallel" is set to false</description>
 		</argument>
 		<return>
 			<type>void</type>

--- a/railo-java/railo-core/src/resource/tld/web-cfmtaglibrary_1_0
+++ b/railo-java/railo-core/src/resource/tld/web-cfmtaglibrary_1_0
@@ -12445,12 +12445,12 @@ dWord: creates a value of 0 (zero)</description>
 			Example single rule:
 			#{interval:createTimeSpan(0,0,0,5),tries:5}#
 
-			in this case Railo replay the thread for maximal 5 times, when the execution fails, Railo waits for 5 seconds before doing the next try.
+			in this case Railo replay the thread for a maximum of 5 times, when the execution fails, Railo waits for 5 seconds before doing the next try.
 
 			Example multiple rules:
 			#[{interval:createTimeSpan(0,0,0,5),tries:5},{interval:createTimeSpan(0,0,0,10),tries:5}]#
 
-			in this case Railo replay the thread for maximal 10 times, when the execution fails, 5 times every 5 seconds, then 5 times every 10 seconds.
+			in this case Railo replay the thread for maximum of 10 times, when the execution fails, 5 times every 5 seconds, then 5 times every 10 seconds.
 			</description>
 		</attribute>
 		<attribute>
@@ -13703,7 +13703,7 @@ dWord: creates a value of 0 (zero)</description>
 			<name>videoBitrateMax</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
-			<description>maximal video bitrate of variable bitrate, default same as input or part of defined quality (example: 10kbps, 10mbps, 10bps)</description>
+			<description>maximum video bitrate of variable bitrate, default same as input or part of defined quality (example: 10kbps, 10mbps, 10bps)</description>
 		</attribute>
 		<attribute>
 			<type>string</type>
@@ -13746,7 +13746,7 @@ dWord: creates a value of 0 (zero)</description>
 			<name>max</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
-			<description>maximal length of destination video, you can defines max frame (10f) or max time (1145ms,3.123s)</description>
+			<description>maximum length of destination video, you can defines max frame (10f) or max time (1145ms,3.123s)</description>
 		</attribute>
 		<attribute>
 			<type>string</type>

--- a/railo-java/railo-loader/src/railo/runtime/ext/tag/TagMetaData.java
+++ b/railo-java/railo-loader/src/railo/runtime/ext/tag/TagMetaData.java
@@ -53,8 +53,8 @@ public interface TagMetaData {
 	 */
 	public int getAttributeMin();
 	/**
-	 * maximal count of attributes needed for tag
-	 * @return maximal count of attributes or -1 for infinity attributes
+	 * maximum count of attributes needed for tag
+	 * @return maximum count of attributes or -1 for infinity attributes
 	 */
 	public int getAttributeMax();
 	


### PR DESCRIPTION
There are a number of places where the word "maximal" is used, this is a fix for that, changing it to maximum and changing the grammar of a number of sentences.
