### PR TITLE
removed red on red from css

### DIFF
--- a/railo-cfml/railo-admin/admin/resources/css/style40.css.cfm
+++ b/railo-cfml/railo-admin/admin/resources/css/style40.css.cfm
@@ -817,9 +817,7 @@ body.server #remotekey {
 	background: url(../img/info.png.cfm) no-repeat;
 	vertical-align:text-bottom;
 }
-.important {
-	background-color:red !important;
-}
+
 .helptextimage .inner {
 	display:none;
 }


### PR DESCRIPTION
I will issue a separate pull for 4.1 as we use a different filename there.

when testing be sure to refresh the browser so that you don't see the older, cached, version.
