### PR TITLE
cfdump error in compiled code. 

### DIFF
--- a/railo-java/railo-core/src/resource/library/tag/Dump.cfc
+++ b/railo-java/railo-core/src/resource/library/tag/Dump.cfc
@@ -66,13 +66,13 @@ component {
 		var context = GetCurrentContext();
 		var contextLevel = structKeyExists(attrib,'contextLevel') ? attrib.contextLevel : 2;
 		contextLevel = min(contextLevel,arrayLen(context));
-+		if ( contextLevel gt 0 ) {
-+			context = context[contextLevel].template & ":" &
-+					context[contextLevel].line;
-+		}
-+		else {
-+			context = '[unknown file]:[unknown line]';
-+		}
+		if ( contextLevel gt 0 ) {
+			context = context[contextLevel].template & ":" &
+					context[contextLevel].line;
+		}
+		else {
+			context = '[unknown file]:[unknown line]';
+		}
 
 		// format
 		attrib['format'] = trim(attrib.format);

--- a/railo-java/railo-core/src/resource/library/tag/Dump.cfc
+++ b/railo-java/railo-core/src/resource/library/tag/Dump.cfc
@@ -66,7 +66,13 @@ component {
 		var context = GetCurrentContext();
 		var contextLevel = structKeyExists(attrib,'contextLevel') ? attrib.contextLevel : 2;
 		contextLevel = min(contextLevel,arrayLen(context));
-		context = context[contextLevel].template & ":" & context[contextLevel].line;
++		if ( contextLevel gt 0 ) {
++			context = context[contextLevel].template & ":" &
++					context[contextLevel].line;
++		}
++		else {
++			context = '[unknown file]:[unknown line]';
++		}
 
 		// format
 		attrib['format'] = trim(attrib.format);


### PR DESCRIPTION
We couldn't figure out why our how. but sometimes the contextLevel variable in Dump.cfc ends up being zero. Which ends up being an index into a an array... causing the error in our 1 based environment :). 
