### PR TITLE
railo admin cosmetic fixes

### DIFF
--- a/railo-cfml/railo-admin/admin/debug/Classic.cfc
+++ b/railo-cfml/railo-admin/admin/debug/Classic.cfc
@@ -146,7 +146,7 @@ millisecond:"ms"
 		</tr>
 		<tr>
 			<td class="cfdebug" nowrap> Template </td>
-			<td class="cfdebug">#_cgi.SCRIPT_NAME# (#expandPath(_cgi.SCRIPT_NAME)#)</td>
+			<td class="cfdebug">#_cgi.SCRIPT_NAME# (#_cgi.cf_template_path)</td>
 		</tr>
 		<tr>
 			<td class="cfdebug" nowrap> Time Stamp </td>

--- a/railo-cfml/railo-admin/admin/debug/Classic.cfc
+++ b/railo-cfml/railo-admin/admin/debug/Classic.cfc
@@ -146,7 +146,7 @@ millisecond:"ms"
 		</tr>
 		<tr>
 			<td class="cfdebug" nowrap> Template </td>
-			<td class="cfdebug">#_cgi.SCRIPT_NAME# (#_cgi.cf_template_path)</td>
+			<td class="cfdebug">#_cgi.SCRIPT_NAME# (#_cgi.cf_template_path#)</td>
 		</tr>
 		<tr>
 			<td class="cfdebug" nowrap> Time Stamp </td>

--- a/railo-cfml/railo-admin/admin/debug/Modern.cfc
+++ b/railo-cfml/railo-admin/admin/debug/Modern.cfc
@@ -224,7 +224,7 @@
 							<table class="tbl" cellpadding="2" cellspacing="0">
 								<tr>
 									<td class="cfdebug" nowrap>Template</td>
-									<td class="cfdebug">#_cgi.SCRIPT_NAME# (#expandPath(_cgi.SCRIPT_NAME)#)</td>
+									<td class="cfdebug">#_cgi.SCRIPT_NAME# (#_cgi.cf_template_path#)</td>
 								</tr>
 								<tr>
 									<td class="cfdebug" nowrap>User Agent</td>

--- a/railo-cfml/railo-admin/admin/overview.cfm
+++ b/railo-cfml/railo-admin/admin/overview.cfm
@@ -447,13 +447,13 @@ Error Output --->
 					<h3>
 						<a href="https://jira.jboss.org/jira/browse/RAILO" target="_blank">#stText.Overview.issueTracker#</a>
 					</h3>
-					<div class="comment">#stText.Overview.bookDesc#</div>
+					<div class="comment">#stText.Overview.issueTrackerDesc#</div>
 					
 					<!--- Blog --->
 					<h3>
 						<a href="http://blog.getrailo.com/" target="_blank">#stText.Overview.blog#</a>
 					</h3>
-					<div class="comment">#stText.Overview.bookDesc#</div>
+					<div class="comment">#stText.Overview.blogDesc#</div>
 					
 					
 					

--- a/railo-cfml/railo-admin/admin/services.mail.cfm
+++ b/railo-cfml/railo-admin/admin/services.mail.cfm
@@ -275,7 +275,7 @@ Defaults --->
 	<cfloop collection="#stVeritfyMessages#" item="hostname">
 		<cfif stVeritfyMessages[hostname].label eq "OK">
 			<div class="message">
-				Verification of mail server [#hostname#] was succesfull.
+				Verification of mail server [#hostname#] was succesful.
 			</div>
 		<cfelse>
 			<div class="error">


### PR DESCRIPTION
Spelling mistake on mail server verification (sucessfull).

On the overview page 'Blog' and 'Issue Tracker' show the description for 'Book'.

The Classic and Modern debug templates show the wrong template path when executed under a non-root context.
