### PR TITLE
Non-thread-safe HashSet used in static methods

### DIFF
--- a/railo-java/railo-core/src/railo/commons/color/ConstantsDouble.java
+++ b/railo-java/railo-core/src/railo/commons/color/ConstantsDouble.java
@@ -1,7 +1,9 @@
 package railo.commons.color;
 
 import java.lang.reflect.Field;
-import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Collections;
 
 import railo.runtime.op.Caster;
 
@@ -1110,12 +1112,12 @@ public class ConstantsDouble {
 	public static Double _100 = new Double(100.0d);
 
 	
-	private static HashSet<String> _____keys;
+	private static Set<String> _____keys;
 	
 	public static String getFieldName(double d) {
 		if(_____keys==null) {
 			Field[] fields = ConstantsDouble.class.getFields();
-			_____keys=new HashSet<String>();
+			_____keys=Collections.newSetFromMap(new ConcurrentHashMap<String,Boolean>());
 			for(int i=0;i<fields.length;i++){
 				if(fields[i].getType()!=Double.class) continue;
 				_____keys.add(fields[i].getName());

--- a/railo-java/railo-core/src/railo/runtime/type/util/KeyConstants.java
+++ b/railo-java/railo-core/src/railo/runtime/type/util/KeyConstants.java
@@ -1,7 +1,9 @@
 package railo.runtime.type.util;
 
 import java.lang.reflect.Field;
-import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Collections;
 
 import railo.runtime.type.Collection.Key;
 import railo.runtime.type.KeyImpl;
@@ -838,12 +840,12 @@ public class KeyConstants {
 	public static final Key _exception = KeyImpl._const("exception");
 	public static final Key _parsebody = KeyImpl._const("parsebody");
 	
-	private static HashSet<String> _____keys;
+	private static Set<String> _____keys;
 	
 	public static String getFieldName(String key) {
 		if(_____keys==null) {
 			Field[] fields = KeyConstants.class.getFields();
-			_____keys=new HashSet<String>();
+			_____keys=Collections.newSetFromMap(new ConcurrentHashMap<String,Boolean>());
 			for(int i=0;i<fields.length;i++){
 				if(fields[i].getType()!=Key.class) continue;
 				_____keys.add(fields[i].getName());


### PR DESCRIPTION
see 
https://groups.google.com/forum/?fromgroups=#!searchin/railo/thread$20hang/railo/VyRZWb_nu-k/4WFwZVTWG_YJ

I do not have reproduction steps. I can't verify that it is an issue. I can't consistently reproduce, so I do not know if this fixes it, but I do know two things:

1) HashSet is not thread safe by itself, and it is being used in the two static classes that are in this pull.
2) I haven't ran into an issue yet since applying this change.

There might be a better way to implement this I was going for changing the least amount of code. Feel free to reject and find a better way. As long as it works :)

Thank you!
