### PR TITLE
replaceNoCase was using the source string as the replace string.

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/functions/string/ReplaceNoCase.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/string/ReplaceNoCase.java
@@ -3,11 +3,8 @@
  */
 package railo.runtime.functions.string;
 
-import java.util.Map;
-
 import railo.commons.lang.StringUtil;
 import railo.runtime.PageContext;
-import railo.runtime.exp.ExpressionException;
 import railo.runtime.exp.FunctionException;
 import railo.runtime.exp.PageException;
 import railo.runtime.ext.function.Function;
@@ -15,6 +12,8 @@ import railo.runtime.op.Caster;
 import railo.runtime.op.Decision;
 
 public final class ReplaceNoCase implements Function {
+
+	private static final long serialVersionUID = -8001488161940178031L;
 
 	public static String call(PageContext pc , String str, String sub1, String sub2) throws FunctionException {
 		return _call(pc, str, sub1, sub2, true);
@@ -24,11 +23,11 @@ public final class ReplaceNoCase implements Function {
 		return _call(pc, str, sub1, sub2, !scope.equalsIgnoreCase("all"));
 	}
 
-	public static String call( PageContext pc, String input, Object find, String repl, String scope ) throws ExpressionException {
+	public static String call( PageContext pc, String input, Object find, String repl, String scope ) throws PageException {
 		return _call(pc, input, find, repl, !scope.equalsIgnoreCase("all") );
 	}
 
-	public static String call( PageContext pc, String input, Object find, String repl ) throws ExpressionException {
+	public static String call( PageContext pc, String input, Object find, String repl ) throws PageException {
 		return _call(pc, input, find, repl, true);
 	}
 	
@@ -38,10 +37,10 @@ public final class ReplaceNoCase implements Function {
 		return StringUtil.replace(str, sub1, sub2, onlyFirst, true);
 	}
 	
-	private static String _call( PageContext pc, String input, Object find, String repl , boolean onlyFirst) throws ExpressionException {
+	private static String _call( PageContext pc, String input, Object find, String repl , boolean onlyFirst) throws PageException {
 		if(!Decision.isSimpleValue(find ) )
 			throw new FunctionException(pc,"ReplaceNoCase",2,"sub1","When passing three parameters or more, the second parameter must be a String.");
-		return _call(pc, input, Caster.toString(input), repl, onlyFirst);
+		return _call(pc, input, Caster.toString(find), repl, onlyFirst);
 	}
 	
 	public static String call( PageContext pc, String input, Object struct ) throws PageException {


### PR DESCRIPTION
the 3-argument version of replaceNoCase was using the source string as the string to replace. This fixes it.
