### PR TITLE
multipart response boundary subheader needs a trim

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/net/http/MultiPartResponseUtils.java
+++ b/railo-java/railo-core/src/railo/runtime/net/http/MultiPartResponseUtils.java
@@ -47,7 +47,7 @@ public class MultiPartResponseUtils {
 		String[] headerSections = ListUtil.listToStringArray(contentTypeHeader, ';');
 		for (String section: headerSections) {
 			String[] subHeaderSections = ListUtil.listToStringArray(section,'=');
-			String headerName = subHeaderSections[0];
+			String headerName = subHeaderSections[0].trim();
 			if (headerName.toLowerCase().equals("boundary")) {
 				return subHeaderSections[1];
 			}


### PR DESCRIPTION
if multipart header has a space before the boundary subheader name, multipart content will break. Trimming the header for comparison
