### PR TITLE
solves ticket https://issues.jboss.org/browse/RAILO-2327

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/functions/system/GetLocalHostIP.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/system/GetLocalHostIP.java
@@ -7,15 +7,38 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import railo.commons.net.IPUtil;
 import railo.runtime.PageContext;
 import railo.runtime.ext.function.Function;
 
 public final class GetLocalHostIP implements Function {
-	public static String call(PageContext pc)  {
-		try {
+
+	public static Object call(PageContext pc)  {
+		return callLegacy();
+	}
+
+
+    public static Object call(PageContext pc, boolean all, boolean refresh) {
+
+        if ( all )
+            return IPUtil.getLocalIPs( refresh );
+
+        return callLegacy();
+    }
+
+
+    public static Object call(PageContext pc, boolean all) {
+
+        return call( pc, all, false );
+    }
+
+
+    static String callLegacy() {
+
+        try {
             if(InetAddress.getLocalHost() instanceof Inet6Address) return "::1";
         }
         catch(UnknownHostException e) {}
         return "127.0.0.1";
-	}
+    }
 }

--- a/railo-java/railo-core/src/resource/fld/web-cfmfunctionlibrary_1_0
+++ b/railo-java/railo-core/src/resource/fld/web-cfmfunctionlibrary_1_0
@@ -5528,8 +5528,20 @@ The returned number of unallocated bytes is a hint, but not a guarantee, that it
 		<name>GetLocalHostIP</name>
 		<class>railo.runtime.functions.system.GetLocalHostIP</class>
 		<description>Returns the localhost IP address, which is 127.0.0.1 for IPv4 and ::1 for IPv6 addresses.</description>
+		<argument>
+		    <name>all</name>
+		    <type>boolean</type>
+		    <required>false</required>
+		    <description>pass true to get an Array with all of the local IP addresses. default [false] will return a String with one value.</description>
+		</argument>
+		<argument>
+            <name>refresh</name>
+            <type>boolean</type>
+            <required>false</required>
+            <description>on some systems getting all of the IP addresses can take some time so the result is cached after the first call, if the system's IP addresses were modified, pass true to refresh that cache.</description>
+        </argument>
 		<return>
-			<type>string</type>
+			<type>any</type>
 		</return>
 	</function>
 	


### PR DESCRIPTION
added two optional args to GetLocalHostIP():

GetLocalHostIP( boolean all=false, boolean refresh=false )

since the return type is now ANY instead of STRING, I can not keep the old signature in railo.runtime.functions.system.GetLocalHostIP

this functionality will be used in tickets like RAILO-1600 as well as tickets RAILO-2201 and RAILO-2322 via the admin
