### PR TITLE
Minor Connection Closing issues.

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/db/DCStack.java
+++ b/railo-java/railo-core/src/railo/runtime/db/DCStack.java
@@ -24,21 +24,6 @@ class DCStack {
 		try {
 			
 			if(!rtn.getConnection().isClosed()){
-				if(rtn.getDatasource().getConnectionTimeout()==0){
-					int dcid = ((DatasourceConnectionImpl)rtn).getRequestId();
-					int pcid = ((PageContextImpl)ThreadLocalPageContext.get(pc)).getRequestId();
-					if(dcid==-1){
-						((DatasourceConnectionImpl)rtn).setRequestId(pcid);
-						return rtn;
-					}
-					if(dcid!=pcid) {
-						try {
-				    		 if(rtn.getConnection()!=null)rtn.getConnection().close();
-				    	 } 
-				    	 catch (Throwable t) {}
-						return null;
-					}
-				}
 				return rtn;
 			}
 		} 

--- a/railo-java/railo-core/src/railo/runtime/db/DatasourceConnectionImpl.java
+++ b/railo-java/railo-core/src/railo/runtime/db/DatasourceConnectionImpl.java
@@ -56,7 +56,7 @@ public final class DatasourceConnectionImpl implements DatasourceConnection {
     @Override
     public boolean isTimeout() {
         int timeout=datasource.getConnectionTimeout();
-        if(timeout<1)timeout=1;
+        if(timeout <= 0) return false;
         timeout*=60000;      
         return (time+timeout)<System.currentTimeMillis();
     }

--- a/railo-java/railo-core/src/railo/runtime/db/DatasourceConnectionPool.java
+++ b/railo-java/railo-core/src/railo/runtime/db/DatasourceConnectionPool.java
@@ -154,13 +154,14 @@ public class DatasourceConnectionPool {
 
 	private DCStack getDCStack(DataSource datasource, String user, String pass) {
 		String id = createId(datasource,user,pass);
+		synchronized(id) {
+			DCStack stack=dcs.get(id);
 		
-		DCStack stack=dcs.get(id);
-		
-		if(stack==null){
-			dcs.put(id, stack=new DCStack());
+			if(stack==null){
+				dcs.put(id, stack=new DCStack());
+			}
+			return stack;
 		}
-		return stack;
 	}
 	
 	public int openConnections() {


### PR DESCRIPTION
1) If two threads on the same application try to get the same 'DCStack' there is a situation (though rare) that the threads could get references to two different stacks. Not sure if this will have any negative affect at all, IF it did happen.
2) if connectionTimeout==0, it makes the connection timeout = 1 second. Changed it so if it is less than or equal to zero, to essentially mean NO timeout. (I might be wrong in my assumption, but the rest of the code appears to want to do this).
3) Getting closed connections at random times, as far as I can tell there is some code in DCstack that is not needed that closes connections. When I remove it, it appears to fix the random closed connection issues.

I am open to discussion about this. I know these changes are working well for me, but I don't know if I am opening my system up to other problems.

Thank you!
