### PR TITLE
Synchronize HashSet which can become corrupted under load (JIRA Issue #2438)

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/cache/ram/RamCache.java
+++ b/railo-java/railo-core/src/railo/runtime/cache/ram/RamCache.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 
 import railo.commons.io.SystemUtil;
 import railo.commons.io.cache.CacheEntry;
@@ -19,7 +20,7 @@ import railo.runtime.type.Struct;
 public class RamCache extends CacheSupport {
 
 	private static final int DEFAULT_CONTROL_INTERVALL = 60;
-	private Map<String, RamCacheEntry> entries= new HashMap<String, RamCacheEntry>();
+	private Map<String, RamCacheEntry> entries= new ConcurrentHashMap<String, RamCacheEntry>();
 	private long missCount;
 	private int hitCount;
 	

--- a/railo-java/railo-core/src/railo/runtime/type/util/KeyConstants.java
+++ b/railo-java/railo-core/src/railo/runtime/type/util/KeyConstants.java
@@ -2,7 +2,9 @@ package railo.runtime.type.util;
 
 import java.lang.reflect.Field;
 import java.util.HashSet;
+import java.util.Set;
 
+import railo.commons.collections.Collections;
 import railo.runtime.type.Collection.Key;
 import railo.runtime.type.KeyImpl;
 
@@ -821,12 +823,12 @@ public class KeyConstants {
 	public static final Key _exception = KeyImpl._const("exception");
 	public static final Key _parsebody = KeyImpl._const("parsebody");
 	
-	private static HashSet<String> _____keys;
+	private static Set<String> _____keys;
 	
 	public static String getFieldName(String key) {
 		if(_____keys==null) {
 			Field[] fields = KeyConstants.class.getFields();
-			_____keys=new HashSet<String>();
+			_____keys=Collections.synchronizedSet(new HashSet<String>());
 			for(int i=0;i<fields.length;i++){
 				if(fields[i].getType()!=Key.class) continue;
 				_____keys.add(fields[i].getName());


### PR DESCRIPTION
Hi,

We've experienced some problems with Railo 4.0.4 under load (see stack trace in JIRA issue #2438 https://issues.jboss.org/browse/RAILO-2438).  This patch wraps the the HashSet in a Collections.synchronizedSet().
