### PR TITLE
added exported attr to classpathentry and CGI dump to debug project

### DIFF
--- a/railo-java/libs/.classpath
+++ b/railo-java/libs/.classpath
@@ -74,6 +74,7 @@
 	<classpathentry exported="true" kind="lib" path="postgresql.jar"/>
 	<classpathentry exported="true" kind="lib" path="serializer.jar"/>
 	<classpathentry exported="true" kind="lib" path="slf4j-api.jar"/>
+	<classpathentry exported="true" kind="lib" path="slf4j-nop.jar"/>
 	<classpathentry exported="true" kind="lib" path="ss_css2.jar"/>
 	<classpathentry exported="true" kind="lib" path="sun-activation.jar"/>
 	<classpathentry exported="true" kind="lib" path="sun-jai_codec.jar"/>
@@ -105,6 +106,5 @@
 	<classpathentry kind="lib" path="apache-commons-httpmime.jar"/>
 	<classpathentry kind="lib" path="xmlbeans.jar"/>
 	<classpathentry kind="lib" path="javasysmon.jar"/>
-	<classpathentry kind="lib" path="slf4j-nop.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/railo-java/railo-debug/web/index.cfm
+++ b/railo-java/railo-debug/web/index.cfm
@@ -1,2 +1,6 @@
-<h1>Railo is running in Debug!</h1>
+<cfoutput>
 
+	<h1>Railo #Server.Railo.Version# is running in Debug</h1>
+
+	<cfdump eval="CGI">
+</cfoutput>


### PR DESCRIPTION
Eclipse couldn't recognize the lib on my system without this attribute.

TBH I don't think that we need this entry at all as this is only loaded at runtime by the slf4j-api lib;  you probably only needed it before this was removed:
https://github.com/getrailo/railo/commit/c207c8604ff3ca71630594ca9cf73f8d5d6baf4f#L1L378
