### PR TITLE
control character serialization for remote cfcs

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/net/rpc/RPCConstants.java
+++ b/railo-java/railo-core/src/railo/runtime/net/rpc/RPCConstants.java
@@ -10,5 +10,5 @@ public final class RPCConstants {
 	public static QName ARRAY_QNAME=new QName("http://rpc.xml.coldfusion","Array");
     //private static QName componentQName=new QName("http://components.test.jm","address");
     //private static QName dateTimeQName=new QName("http://www.w3.org/2001/XMLSchema","dateTime");
-    
+    public static final QName STRING_QNAME = new QName("http://www.w3.org/2001/XMLSchema", "string");
 }

--- a/railo-java/railo-core/src/railo/runtime/net/rpc/TypeMappingUtil.java
+++ b/railo-java/railo-core/src/railo/runtime/net/rpc/TypeMappingUtil.java
@@ -7,6 +7,9 @@ import javax.xml.rpc.encoding.TypeMappingRegistry;
 import org.apache.axis.encoding.ser.BeanDeserializerFactory;
 import org.apache.axis.encoding.ser.BeanSerializerFactory;
 
+import railo.runtime.net.rpc.server.StringDeserializerFactory;
+import railo.runtime.net.rpc.server.StringSerializerFactory;
+
 import coldfusion.xml.rpc.QueryBean;
 
 public class TypeMappingUtil {
@@ -18,10 +21,15 @@ public class TypeMappingUtil {
                 RPCConstants.QUERY_QNAME,
                 new BeanSerializerFactory(QueryBean.class,RPCConstants.QUERY_QNAME),
                 new BeanDeserializerFactory(QueryBean.class,RPCConstants.QUERY_QNAME));
+		
+		//Adding custom string serialization for non printable characters.
+		tm.register(String.class,
+				RPCConstants.STRING_QNAME,
+				new StringSerializerFactory(String.class, RPCConstants.STRING_QNAME),
+				new StringDeserializerFactory(String.class, RPCConstants.STRING_QNAME));
 	}
 	
 	public static void registerBeanTypeMapping(javax.xml.rpc.encoding.TypeMapping tm, Class clazz, QName qName) {
-		
 		if(tm.isRegistered(clazz, qName)) return;
 		tm.register(
     			clazz, 

--- a/railo-java/railo-core/src/railo/runtime/net/rpc/server/StringDeserializer.java
+++ b/railo-java/railo-core/src/railo/runtime/net/rpc/server/StringDeserializer.java
@@ -1,0 +1,34 @@
+package railo.runtime.net.rpc.server;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import javax.xml.namespace.QName;
+
+import org.apache.axis.encoding.ser.SimpleDeserializer;
+
+public class StringDeserializer extends SimpleDeserializer {
+	private static final Map<Pattern, String> replacements;
+	static {
+		replacements = new HashMap<Pattern, String>();
+		for (char c = 0x00; c <= 0x1F; ++c) {
+			replacements.put(Pattern.compile(StringSerializer.xmlCodeForChar(c)), Character.toString(c));
+		}
+		replacements.put(Pattern.compile(StringSerializer.xmlCodeForChar((char) 0x7F)), Character.toString((char) 0x7F));
+	}
+
+	public StringDeserializer(Class javaType, QName xmlType) {
+		super(javaType, xmlType);
+	}
+
+	public Object makeValue(String source) throws Exception {
+		String val = source; 
+
+		for (Pattern pattern : replacements.keySet()) {
+			val = pattern.matcher(val).replaceAll(replacements.get(pattern));
+		}
+
+		return val; 
+	}
+}

--- a/railo-java/railo-core/src/railo/runtime/net/rpc/server/StringDeserializerFactory.java
+++ b/railo-java/railo-core/src/railo/runtime/net/rpc/server/StringDeserializerFactory.java
@@ -1,0 +1,19 @@
+package railo.runtime.net.rpc.server;
+
+import javax.xml.namespace.QName;
+import javax.xml.rpc.encoding.Deserializer;
+import org.apache.axis.encoding.ser.SimpleDeserializerFactory;
+
+public class StringDeserializerFactory extends SimpleDeserializerFactory {
+	public StringDeserializerFactory(Class javaType, QName xmlType) {
+		super(javaType, xmlType);
+	}
+	
+	public Deserializer getDeserializerAs(String mechanismType) {
+		if (javaType == String.class) {
+			return new StringDeserializer(javaType, xmlType);
+		}
+		
+		return super.getDeserializerAs(mechanismType);
+	}
+}

--- a/railo-java/railo-core/src/railo/runtime/net/rpc/server/StringSerializer.java
+++ b/railo-java/railo-core/src/railo/runtime/net/rpc/server/StringSerializer.java
@@ -1,0 +1,42 @@
+package railo.runtime.net.rpc.server;
+
+import javax.xml.namespace.QName;
+
+import org.apache.axis.encoding.ser.SimpleSerializer;
+import org.apache.axis.encoding.SerializationContext;
+
+import org.apache.commons.lang.StringUtils;
+
+public class StringSerializer extends SimpleSerializer {
+	protected static String xmlCodeForChar(char c) {
+		StringBuilder buff = new StringBuilder();
+		buff.append("&#x");
+		buff.append(StringUtils.leftPad(Integer.toHexString(c), 4, "0"));
+		buff.append(";"); 
+		
+		return buff.toString();
+	}
+
+    public StringSerializer(Class javaType, QName xmlType) {
+		super(javaType, xmlType);
+	}
+
+	public String getValueAsString(Object value, SerializationContext context) {
+        return escapeNonPrintableChars(super.getValueAsString(value, context));
+    }
+
+	private String escapeNonPrintableChars(String val) {
+		StringBuilder buff = new StringBuilder();
+		for (int idx = 0; idx < val.length(); ++idx) {
+			char c = val.charAt(idx);
+			buff.append(charIsNonPrintable(c) ? xmlCodeForChar(c) : c);
+		}
+		
+		return buff.toString(); 
+	}
+
+	private boolean charIsNonPrintable(char c) {
+		//0x00 to 0x1F and 0x7F are ASCII control characters
+		return c < 0x1F || c == 0x7F;
+	}
+}

--- a/railo-java/railo-core/src/railo/runtime/net/rpc/server/StringSerializerFactory.java
+++ b/railo-java/railo-core/src/railo/runtime/net/rpc/server/StringSerializerFactory.java
@@ -1,0 +1,21 @@
+package railo.runtime.net.rpc.server;
+
+import org.apache.axis.encoding.ser.SimpleSerializerFactory;
+
+import javax.xml.namespace.QName;
+import javax.xml.rpc.JAXRPCException;
+import javax.xml.rpc.encoding.Serializer;
+
+public class StringSerializerFactory extends SimpleSerializerFactory {
+	public StringSerializerFactory(Class javaType, QName xmlType) {
+		super(javaType, xmlType);
+	}
+
+	public Serializer getSerializerAs(String mechanismType) throws JAXRPCException {
+        if (javaType == String.class) {
+            return new StringSerializer(javaType, xmlType);
+        }
+
+        return super.getSerializerAs(mechanismType);
+    }
+}


### PR DESCRIPTION
I found a problem with remote cfc's returning control characters.  If a remote cfc has a function like this:

```
<cffunction name="getChar" output="false" access="remote">
    <cfreturn chr(19) /> <!--- device control 3 character --->
</cffunction>
```

then Axis can not serialize the return value.  I found that it was because Axis and Railo wasn't escaping control characters before writing the Soap response XML.  So I added a custom Serializer and Deserializer for the java.lang.String class that will use XML escape characters like, `&#x00131`.  Hopefully it is somewhat useful.  I do realize that many are not using Soap anymore and changes to Railo's Soap support might be low priority.
