### PR TITLE
removed version information from comment for security reasons.

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/PageContextImpl.java
+++ b/railo-java/railo-core/src/railo/runtime/PageContextImpl.java
@@ -1871,9 +1871,7 @@ public final class PageContextImpl extends PageContext implements Sizeable {
 			
 			
 			try {
-				if(statusCode!=404)
-					forceWrite("<!-- Railo ["+Info.getVersionAsString()+"] Error -->");
-				
+
 				String template=getConfig().getErrorTemplate(statusCode);
 				if(!StringUtil.isEmpty(template)) {
 					try {


### PR DESCRIPTION
this can be added to the template that displays the error if needed.
