### PR TITLE
componentListPackage substring error

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/functions/component/ComponentListPackage.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/component/ComponentListPackage.java
@@ -183,10 +183,13 @@ public class ComponentListPackage implements Function {
 					
 					if(StringUtil.isEmpty(sourceName)) {
 						c=IOUtil.toString(children[i],(Charset)null);
-						c=c.substring(0,c.indexOf("<clinit>"));
-						c = ListUtil.last(c, "/\\",true).trim();
-						if(StringUtil.endsWithIgnoreCase(c, ".cfc"))
-							list.add(c);
+						int loc = c.indexOf("<clinit>");
+						if(loc !=-1) {
+							c=c.substring(0,loc);
+							c = ListUtil.last(c, "/\\",true).trim();
+							if(StringUtil.endsWithIgnoreCase(c, ".cfc"))
+								list.add(c);
+						}
 					}
 					else list.add(sourceName);
 					


### PR DESCRIPTION
Long story short. I get an error with componentListPackage() when used inside an archive-first mapping. Unfortunately, it doesn't do it for all my archive-first mappings. BUT it does do it for the /railo-context mapping. If you switch that to be an "archive-first" mapping and login and view the datasource page in the admin, it will error. It looks like it can't find the <clinit> 'tag' in the class's bytes. I think it might have to do with the default encoding when reading the file (as that has changed lately). I thought about adding a function to ClassUtils.java that will get the source name from class binary by reading the java file and looking up the 5th entry in the constant pool. I decided to make componentListPackage at least NOT error if it can't find <clinit> in the class file.

If you want me to open a ticket for this let me know. I hesitate because I am not sure if I am just doing something wrong or not. 
