### PR TITLE
Allow explicit datasource config (struct) for cfquery tag.

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/tag/Query.java
+++ b/railo-java/railo-core/src/railo/runtime/tag/Query.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.TimeZone;
 
 import railo.commons.date.TimeZoneUtil;
+import railo.commons.lang.ClassException;
 import railo.commons.lang.StringUtil;
 import railo.runtime.PageContext;
 import railo.runtime.PageContextImpl;
@@ -24,6 +25,7 @@ import railo.runtime.exp.DatabaseException;
 import railo.runtime.exp.ExpressionException;
 import railo.runtime.exp.PageException;
 import railo.runtime.ext.tag.BodyTagTryCatchFinallyImpl;
+import railo.runtime.listener.AppListenerUtil;
 import railo.runtime.listener.ApplicationContextPro;
 import railo.runtime.op.Caster;
 import railo.runtime.op.Decision;
@@ -210,9 +212,19 @@ public final class Query extends BodyTagTryCatchFinallyImpl {
 	/** set the value datasource
 	*  The name of the data source from which this query should retrieve data.
 	* @param datasource value to set
+	 * @throws ClassException 
 	**/
-	public void setDatasource(String datasource) throws PageException	{
-		this.datasource=((PageContextImpl)pageContext).getDataSource(datasource);
+
+	public void setDatasource(Object datasource) throws PageException, ClassException	{
+		if (Decision.isString(datasource)) {
+			this.datasource=((PageContextImpl)pageContext).getDataSource((String)datasource);
+		} else if (Decision.isStruct(datasource)) {
+			this.datasource=AppListenerUtil.toDataSource("__temp__", (Struct)datasource);
+		} else {
+			throw new ApplicationException("attribute [datasource] must be datasource name or a datasource definition(struct)");
+			
+		}
+
 	}
 
 	/** set the value timeout

--- a/railo-java/railo-core/src/resource/tld/web-cfmtaglibrary_1_0
+++ b/railo-java/railo-core/src/resource/tld/web-cfmtaglibrary_1_0
@@ -9772,7 +9772,7 @@ Manipulates existing PDF documents. The following list describes some of the tas
             - ExecutionTime: Execution time for the SQL request. (numeric)</description>
 		</attribute>
 		<attribute>
-			<type>string</type>
+			<type>any</type>
 			<name>dataSource</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>


### PR DESCRIPTION
I asked on google groups how I can store a datasource's connection parameters and load it from any node in my cluster and run a query against it without having to propogate datasources in railo admins, or hard coding them in application cfcs. While I was waiting for an answer (and assuming there was no answer). I implemented this pull request. which allows you to specify a datasource config 'inline' in the cfquery datasource attribute. After I implemented this I learned of <cfapplication action="update" which allows me to add a datasource available for the remainder of the request. This was satisfactory... but I couldn't bring myself to revert this code. If you see any value in this feel free to merge (you might want to implement it for the other datasource tags... cfdbinfo, cfupdate, etc). If not, thats cool too.

Thanks for the mighty fine work with railo.
