### PR TITLE
suppress exception if dir exists and createPath is true

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/tag/Directory.java
+++ b/railo-java/railo-core/src/railo/runtime/tag/Directory.java
@@ -575,7 +575,7 @@ public final class Directory extends TagImpl  {
 				throw new ApplicationException("directory ["+directory.toString()+"] already exist");
 			}
 			if(directory.isFile())
-				throw new ApplicationException("can't create directory ["+directory.toString()+"], it exist a file with same name");
+				throw new ApplicationException("can't create directory ["+directory.toString()+"], a file with that name exists at that location");
 		}
 		//if(!directory.mkdirs())	throw new ApplicationException("can't create directory ["+directory.toString()+"]");
 		try {

--- a/railo-java/railo-core/src/railo/runtime/tag/Directory.java
+++ b/railo-java/railo-core/src/railo/runtime/tag/Directory.java
@@ -568,9 +568,13 @@ public final class Directory extends TagImpl  {
 	    securityManager.checkFileLocation(pc.getConfig(),directory,serverPassword);
 	    
 		if(directory.exists()) {
-			if(directory.isDirectory())
+			if(directory.isDirectory()) {
+				if ( createPath )
+					return;
+
 				throw new ApplicationException("directory ["+directory.toString()+"] already exist");
-			else if(directory.isFile())
+			}
+			if(directory.isFile())
 				throw new ApplicationException("can't create directory ["+directory.toString()+"], it exist a file with same name");
 		}
 		//if(!directory.mkdirs())	throw new ApplicationException("can't create directory ["+directory.toString()+"]");


### PR DESCRIPTION
if we pass createPath=true then our intent is to create the directory no matter what, therefore there is no reason to throw exception if it already exists which saves the test of if ( !directoryExists(path) ) and the need for locking in a multithreaded scenario.
