### PR TITLE
cffunction localmode added to admin doc

### DIFF
--- a/railo-java/railo-core/src/resource/tld/web-cfmtaglibrary_1_0
+++ b/railo-java/railo-core/src/resource/tld/web-cfmtaglibrary_1_0
@@ -4243,6 +4243,18 @@ no: the function is processed as if it were within a cfsilent tag </description>
 			<rtexprvalue>true</rtexprvalue>
 			<description>A Boolean value that specifies whether to require remote function calls to include an encrypted security token. For use with AJAX applications only.</description>
 		</attribute>
+		<attribute>
+			<type>string</type>
+			<name>localMode</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<description>Defines how the local scope of this function is invoked when a variable with no scope definition is used.  Accepted values include:  
+
+- always: This is an alias for "modern".
+- classic (default): The local scope is only invoked when the key already exists in it.
+- modern: The local scope is always invoked.
+- update: This is an alias for "classic".</description>
+		</attribute>
 	</tag>
 	<!-- Graph -->
 	<tag>


### PR DESCRIPTION
Added the missing localmode attribute documentation for cffunction in railo admin.
