### PR TITLE
added useful method to get the source from an object which could be

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/java/JavaUtil.java
+++ b/railo-java/railo-core/src/railo/runtime/java/JavaUtil.java
@@ -10,14 +10,38 @@ import railo.commons.lang.ClassUtil;
 public class JavaUtil {
 
 
-	public static String getJarPathForClass(String className) {
-		
+	/**
+	 * returns the path that the class was loaded from
+	 *
+	 * @param clazz
+	 * @return
+	 */
+	public static String getJarPathForObject(Class clazz) {
+
 		try {
-			Class c = ClassUtil.loadClass(className);
-			String result = c.getProtectionDomain().getCodeSource().getLocation().getPath();
+
+			String result = clazz.getProtectionDomain().getCodeSource().getLocation().getPath();
 			result = URLDecoder.decode(result, Charset.UTF8);
 			result = SystemUtil.fixWindowsPath(result);
 			return result;
+		}
+		catch (Throwable t) {}
+
+		return "";
+	}
+
+
+	/**
+	 * tries to load the class and returns that path it was loaded from
+	 *
+	 * @param className
+	 * @return
+	 */
+	public static String getJarPathForClass(String className) {
+		
+		try {
+
+			return  getJarPathForObject( ClassUtil.loadClass(className) );
 		}
 		catch (Throwable t) {}
 


### PR DESCRIPTION
different from the first loaded class when loading by name.  

so now we can also call 

```
JavaUtil.getJarPathForObject( someObj.getClass() )
```

on a live object to find out where it was loaded from.
