### PR TITLE
issue RAILO-2803: cfchart image paths are invalid when deploying railo

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/tag/Chart.java
+++ b/railo-java/railo-core/src/railo/runtime/tag/Chart.java
@@ -700,7 +700,9 @@ public final class Chart extends BodyTagImpl implements Serializable {
 			copy(res.getOutputStream(),jfc,info);
 		}
 		
-		String src="/railo-context/graph.cfm?img="+id+"&type="+formatToString(format);
+		String contextPath = pageContext.getHttpServletRequest().getContextPath();
+		contextPath = StringUtil.isEmpty(contextPath) ? "/" : contextPath+"/";
+		String src=contextPath+"railo-context/graph.cfm?img="+id+"&type="+formatToString(format);
 		if(!StringUtil.isEmpty(source)) {
 			pageContext.setVariable(source, src);
 			return;


### PR DESCRIPTION
with a context root 
https://issues.jboss.org/browse/RAILO-2803
