### PR TITLE
https://issues.jboss.org/browse/RAILO-2241

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/type/query/SimpleQueryColumn.java
+++ b/railo-java/railo-core/src/railo/runtime/type/query/SimpleQueryColumn.java
@@ -35,8 +35,7 @@ public class SimpleQueryColumn implements QueryColumn {
 	private ResultSet res;
 	private Cast cast;
 	private int index;
-	private Object[] data;
-
+	
 	public SimpleQueryColumn(SimpleQuery qry, ResultSet res, Collection.Key key, int type, int index) {
 		this.qry=qry;
 		this.res=res;
@@ -227,7 +226,6 @@ public class SimpleQueryColumn implements QueryColumn {
 
 	
 	public String castToString() throws PageException {
-		// TODO Auto-generated method stub
 		return Caster.toString(get(key));
 	}
 
@@ -358,8 +356,6 @@ public class SimpleQueryColumn implements QueryColumn {
 
 	@Override
 	public synchronized Object get(int row) throws PageException {
-		Object sv = getStoredValue(row);
-		if(sv!=SimpleQuery.DEFAULT_VALUE) return sv;
 		
 		try {
 			if(row!=res.getRow()) {
@@ -374,8 +370,7 @@ public class SimpleQueryColumn implements QueryColumn {
 
 	@Override
 	public synchronized Object get(int row, Object defaultValue) {
-		Object sv = getStoredValue(row);
-		if(sv!=SimpleQuery.DEFAULT_VALUE) return sv;
+
 		
 		try {
 			if(row!=res.getRow()) {
@@ -388,20 +383,10 @@ public class SimpleQueryColumn implements QueryColumn {
 		}
 	}
 	
-	private synchronized Object getStoredValue(int row) {
-		if(data==null) return SimpleQuery.DEFAULT_VALUE;
-		return data[row-1];
-	}
 	
 	private synchronized Object _get(int row) throws SQLException, IOException {
-		if(data==null) {
-			data=new Object[qry.getRecordcount()];
-			for(int i=0;i<data.length;i++){
-				data[i]=SimpleQuery.DEFAULT_VALUE;
-			}
-			
-		}
-		return data[row-1]=cast.toCFType(null, type, res, index);
+
+		return cast.toCFType(null, type, res, index);
 	}
 
 	


### PR DESCRIPTION
Made cfquery lazy="true" a little extra lazy... by not storing already fetched in memory.  This makes a lazy query slower if you loop over it more than once, but use less memory. Tested with SQL server. 
