### PR TITLE
HQL throws NPE

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/functions/orm/ORMExecuteQuery.java
+++ b/railo-java/railo-core/src/railo/runtime/functions/orm/ORMExecuteQuery.java
@@ -40,7 +40,8 @@ public class ORMExecuteQuery {
 	}
 	private static Object _call(PageContext pc,String hql, Object params, boolean unique, Struct queryOptions) throws PageException {
 		ORMSession session=ORMUtil.getSession(pc);
-		String dsn = Caster.toString(queryOptions.get(KeyConstants._datasource,null),null);
+		String dsn = null;
+		if(queryOptions!=null) dsn = Caster.toString(queryOptions.get(KeyConstants._datasource,null),null);
 		if(StringUtil.isEmpty(dsn,true)) dsn=ORMUtil.getDataSource(pc).getName();
 		
 		if(params==null)

--- a/railo-java/railo-core/src/railo/runtime/tag/Query.java
+++ b/railo-java/railo-core/src/railo/runtime/tag/Query.java
@@ -638,7 +638,8 @@ public final class Query extends BodyTagTryCatchFinallyImpl {
 	private Object executeORM(SQL sql, int returnType, Struct ormoptions) throws PageException {
 		ORMSession session=ORMUtil.getSession(pageContext);
 		
-		String dsn = Caster.toString(ormoptions.get(KeyConstants._datasource,null),null);
+		String dsn = null;
+		if (ormoptions!=null) dsn =	Caster.toString(ormoptions.get(KeyConstants._datasource,null),null);
 		if(StringUtil.isEmpty(dsn,true)) dsn=ORMUtil.getDataSource(pageContext).getName();
 		
 		// params


### PR DESCRIPTION
Not sure what the repro steps are, but <cfquery dbtype="hql"> and ORMExecuteQuery throws an NPE. I tried to figure out what in my application.cfc this.ormsettings is throwing it off, but this fix works. I am not confident I fixed it the right way.

I did not log a jira issue, not sure if this is a real bug or not, or something I have misconfigured. If this is real, let me know and I would be glad to log a jire issue. If it is not real, any tips on what I could be doing wrong for the ormoptions variable to be null.
