### PR TITLE
StructKeyExists(myXML.xmlAttributes,"key") performance improvement

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/text/xml/XMLAttributes.java
+++ b/railo-java/railo-core/src/railo/runtime/text/xml/XMLAttributes.java
@@ -150,11 +150,15 @@ public final class XMLAttributes extends StructSupport implements Struct,NamedNo
 
 	@Override
 	public Object get(Collection.Key key, Object defaultValue) {
-		try {
-			return get(key);
-		} catch (PageException e) {
-			return defaultValue;
+		Node rtn = nodeMap.getNamedItem(key.getString());
+		if(rtn!=null) return rtn.getNodeValue();
+		
+		Collection.Key[] keys=keys();
+		for(int i=0;i<keys.length;i++) {
+			if(key.equalsIgnoreCase(keys[i]))
+				return nodeMap.getNamedItem(keys[i].getString()).getNodeValue();
 		}
+		return defaultValue;
 	}
 
 	@Override


### PR DESCRIPTION
structKeyExists on an xml attributes node when a key does not exist is handled by throwing a page exception and then ignoring it. This has some duplicate code, but you get the idea... do not throw the slow PageException, just to ignore it.
