### PR TITLE
Jira3067

### DIFF
--- a/railo-java/railo-core/src/railo/runtime/config/ConfigWebFactory.java
+++ b/railo-java/railo-core/src/railo/runtime/config/ConfigWebFactory.java
@@ -30,6 +30,8 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
+import com.jacob.com.LibraryLoader;
+
 import railo.aprint;
 import railo.commons.collection.MapFactory;
 import railo.commons.date.TimeZoneUtil;
@@ -981,9 +983,14 @@ public final class ConfigWebFactory extends ConfigFactory {
 		if (!ctDir.exists())
 			ctDir.mkdirs();
 
-		Resource f = binDir.getRealResource("jacob.dll");
-		if (!f.exists())
-			createFileFromResourceEL("/resource/bin/jacob.dll", f);
+		// Jacob
+		if (SystemUtil.isWindows()) {
+			String name = (SystemUtil.getJREArch() == SystemUtil.ARCH_64) ? "jacob-x64.dll" : "jacob-x86.dll";
+			Resource jacob = binDir.getRealResource(name);
+			if (!jacob.exists()) {
+				createFileFromResourceEL("/resource/bin/" + name, jacob);
+			}
+		}
 
 		Resource storDir = configDir.getRealResource("storage");
 		if (!storDir.exists())
@@ -995,6 +1002,7 @@ public final class ConfigWebFactory extends ConfigFactory {
 
 		// remove old cacerts files, they are now only in the server context
 		Resource secDir = configDir.getRealResource("security");
+		Resource f = null;
 		if (secDir.exists()) {
 			f = secDir.getRealResource("cacerts");
 			if (f.exists())
@@ -1029,7 +1037,7 @@ public final class ConfigWebFactory extends ConfigFactory {
 
 		f = contextDir.getRealResource(Constants.APP_CFM);
 		if (!f.exists())
-			createFileFromResourceEL("/resource/context/application.cfm", f);
+			createFileFromResourceEL("/resource/context/Application.cfm", f);
 
 		f = contextDir.getRealResource("form.cfm");
 		if (!f.exists() || doNew)


### PR DESCRIPTION
fixes the paths when initially expanding.  This wasn't a fatal error, it just threw null pointers on first run.
