### PR TITLE
4.2 adminsearch staticindex

### DIFF
--- a/railo-cfml/railo-admin/admin/admin.search.cfm
+++ b/railo-cfml/railo-admin/admin/admin.search.cfm
@@ -14,9 +14,12 @@
 	<cfreturn ret />
 </cffunction>
 
-<cfset railoArchivePath = expandPath("{railo-web}/context/railo-context.ra") />
-<cfset railoArchiveZipPath = "zip://" & railoArchivePath & "!" />
-<cfset dataDir = expandPath("{railo-server}/searchdata") & server.separator.file />
+<cfset dataDir = expandPath("./searchdata") & server.separator.file />
+
+<!--- re-indexing only works when uncompiled Railo source code is used (eg. no railo-context.ra / not from within the Railo admin) --->
+<cfif structKeyExists(url, "reindex")>
+	<cfinclude template="admin.search.index.cfm" />
+</cfif>
 
 <cfset current.label = stText.admin.search.label />
 <cfoutput>
@@ -29,15 +32,19 @@
 		<input type="submit" class="button submit" value="#stText.buttons.search#" />
 	</form>
 </cfoutput>
+
 <cfif structKeyExists(url, 'q') and len(url.q)>
 	<cfset variables.indexFile = '#dataDir#searchindex.cfm' />
 
-	<!--- do initial or new indexing when a new Railo version is detected --->
-	<cfif not fileExists(variables.indexFile)
-	or structKeyExists(url, "reindex")
-	or fileRead('#dataDir#indexed-railo-version.cfm') neq server.railo.version & server.railo['release-date']>
-		<cfinclude template="admin.search.index.cfm" />
-	</cfif>
+	<!--- do initial or new indexing when a new Railo version is detected
+		Nope. We don't have the admin cfm files at the client, so can't index it there.
+		Just use the shipped indexes.
+		<cfif not fileExists(variables.indexFile)
+		or structKeyExists(url, "reindex")
+		or fileRead('#dataDir#indexed-railo-version.cfm') neq server.railo.version & server.railo['release-date']>
+			<cfinclude template="admin.search.index.cfm" />
+		</cfif>
+	--->
 
 	<cfset foundpages = {} />
 	

--- a/railo-cfml/railo-admin/admin/admin.search.index.cfm
+++ b/railo-cfml/railo-admin/admin/admin.search.index.cfm
@@ -2,8 +2,13 @@
 	<cfif not directoryExists(dataDir)>
 		<cfdirectory action="create" directory="#dataDir#" mode="777" recurse="true" />
 	</cfif>
+	
+	<cfset currPath = getDirectoryFromPath(getCurrentTemplatePath()) />
+	<cfif right(currPath, 1) neq server.separator.file>
+		<cfset currPath &= server.separator.file />
+	</cfif>
 
-	<cfdirectory action="list" name="qlangs" directory="#expandPath('{railo-web}/context/admin/resources/language/')#" filter="*.xml" />
+	<cfdirectory action="list" name="qlangs" directory="#currPath#resources/language/" filter="*.xml" />
 
 	<cfset translations = {} />
 	<cfset pageContents = {} />
@@ -25,7 +30,7 @@
 		<cfelse>
 			<cfset temp = duplicate(translations.en) />
 		</cfif>
-		<cfset x = xmlParse(fileread('resources/language/#currfile#', 'utf-8')) />
+		<cfset x = xmlParse(fileread('#currPath#resources/language/#currfile#', 'utf-8')) />
 		<cfloop array="#x.language.data#" index="item">
 			<cfset temp[item.xmlattributes.key] = item.xmlText />
 		</cfloop>
@@ -34,7 +39,7 @@
 	</cfloop>
 
 	<cfset searchresults = {} />
-	<cfdirectory action="list" directory="#railoArchiveZipPath#/admin" filter="*.*.cfm" name="qFiles" sort="name" />
+	<cfdirectory action="list" directory="#currPath#" filter="*.*.cfm" name="qFiles" sort="name" />
 
 	<cfloop query="qFiles">
 		<cfset currFile = qFiles.directory & "/" & qFiles.name />
@@ -85,8 +90,9 @@
 
 	</cfloop>
 
-	<!--- remember the Railo version which is now in use --->
+	<!--- remember the Railo version which is now in use
 	<cffile action="write" file="#datadir#indexed-railo-version.cfm" output="#server.railo.version##server.railo['release-date']#" mode="644" addnewline="no" />
+	--->
 
 	<!--- store the searchresults --->
 	<cffile action="write" file="#datadir#searchindex.cfm" charset="utf-8" output="#serialize(searchresults)#" mode="644" />


### PR DESCRIPTION
As discussed in the railo-team list: the search functionality in the Railo-admin currently does not work anymore, and should use pre-compiled index files. The changes in this pull request make sure there is no local indexing being done anymore, and the admin.search.index.cfm file can now be used in the railo-builder to create the searchindex files.
