### PR TITLE
Trace times are in ms, not nanoseconds

### DIFF
--- a/railo-java/railo-core/src/resource/context/admin/debug/Classic.cfc
+++ b/railo-java/railo-core/src/resource/context/admin/debug/Classic.cfc
@@ -106,7 +106,7 @@ private function isColumnEmpty(query query, string columnName){
 
 <cfset unit={
 millisecond:"ms"
-,microsecond:"µs"
+,microsecond:"ï¿½s"
 ,nanosecond:"ns"
 
 }>
@@ -322,8 +322,8 @@ millisecond:"ms"
 			<cfif hasAction><td align="left" class="cfdebug" nowrap>#traces.action#</td></cfif>
 			<td align="left" class="cfdebug" nowrap><cfif len(traces.varName)>#traces.varName#<cfif structKeyExists(traces,'varValue')> = #traces.varValue#</cfif><cfelse>&nbsp;<br />
 			</cfif></td>
-			<td align="right" class="cfdebug" nowrap>#formatUnit(custom.unit, total)#</td>
-			<td align="right" class="cfdebug" nowrap>#formatUnit(custom.unit, traces.time)#</td>
+			<td align="right" class="cfdebug" nowrap>#formatUnit(custom.unit, total * 1000000)#</td>
+			<td align="right" class="cfdebug" nowrap>#formatUnit(custom.unit, traces.time * 1000000)#</td>
 		</tr>
 </cfloop>                
  </table>


### PR DESCRIPTION
They need to be multiplied \* 1000000 in order to display correctly as milliseconds.
